### PR TITLE
Fix/plcn 283 check and fix hubspot updates on contacts

### DIFF
--- a/src/Pelican.Application/Contacts/HubSpotCommands/Update/UpdateContactHubSpotCommandHandler.cs
+++ b/src/Pelican.Application/Contacts/HubSpotCommands/Update/UpdateContactHubSpotCommandHandler.cs
@@ -1,4 +1,5 @@
-﻿using Pelican.Application.Abstractions.Data.Repositories;
+﻿using Microsoft.EntityFrameworkCore;
+using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.HubSpot;
 using Pelican.Application.Abstractions.Messaging;
 using Pelican.Domain;
@@ -12,6 +13,7 @@ internal sealed class UpdateContactHubSpotCommandHandler : ICommandHandler<Updat
 	private readonly IUnitOfWork _unitOfWork;
 	private readonly IHubSpotObjectService<Contact> _hubSpotContactService;
 	private readonly IHubSpotAuthorizationService _hubSpotAuthorizationService;
+
 	public UpdateContactHubSpotCommandHandler(
 		IUnitOfWork unitOfWork,
 		IHubSpotObjectService<Contact> hubSpotContactService,
@@ -31,11 +33,12 @@ internal sealed class UpdateContactHubSpotCommandHandler : ICommandHandler<Updat
 		UpdateContactHubSpotCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		Contact? contact = await _unitOfWork
+		Contact? contact = _unitOfWork
 			.ContactRepository
-			.FirstOrDefaultAsync(
-				contact => contact.SourceId == command.ObjectId.ToString() && contact.Source == Sources.HubSpot,
-				cancellationToken);
+			.FindByCondition(contact => contact.SourceId == command.ObjectId.ToString() && contact.Source == Sources.HubSpot)
+			.Include(c => c.ClientContacts)
+			.Include(c => c.DealContacts)
+			.FirstOrDefault();
 
 		if (contact is null)
 		{
@@ -45,17 +48,6 @@ internal sealed class UpdateContactHubSpotCommandHandler : ICommandHandler<Updat
 				cancellationToken);
 		}
 
-		return await UpdateExistingContact(
-			contact,
-			command,
-			cancellationToken);
-	}
-
-	private async Task<Result> UpdateExistingContact(
-		Contact contact,
-		UpdateContactHubSpotCommand command,
-		CancellationToken cancellationToken = default)
-	{
 		if ((contact.LastUpdatedAt ?? contact.CreatedAt) <= command.UpdateTime)
 		{
 			if (command.PropertyName == "num_associated_deals")
@@ -80,7 +72,7 @@ internal sealed class UpdateContactHubSpotCommandHandler : ICommandHandler<Updat
 		}
 		else
 		{
-			Result<Contact> result = await GetContactFromHubSpot(
+			Result<Contact> result = await GetContactFromHubSpotAsync(
 				command.SupplierHubSpotId,
 				command.ObjectId,
 				cancellationToken);
@@ -91,12 +83,11 @@ internal sealed class UpdateContactHubSpotCommandHandler : ICommandHandler<Updat
 			}
 
 			contact.UpdatePropertiesFromContact(result.Value);
-			contact.UpdateDealContacts(result.Value.DealContacts);
 		}
 
 		_unitOfWork
 			.ContactRepository
-			.Update(contact);
+			.Attach(contact);
 
 		await _unitOfWork.SaveAsync(cancellationToken);
 
@@ -109,7 +100,7 @@ internal sealed class UpdateContactHubSpotCommandHandler : ICommandHandler<Updat
 		long contactHubSpotId,
 		CancellationToken cancellationToken = default)
 	{
-		Result<Contact> result = await GetContactFromHubSpot(
+		Result<Contact> result = await GetContactFromHubSpotAsync(
 			supplierHubSpotId,
 			contactHubSpotId,
 			cancellationToken);
@@ -129,7 +120,7 @@ internal sealed class UpdateContactHubSpotCommandHandler : ICommandHandler<Updat
 		long objectId,
 		CancellationToken cancellationToken = default)
 	{
-		Result<Contact> result = await GetContactFromHubSpot(
+		Result<Contact> result = await GetContactFromHubSpotAsync(
 			supplierHubSpotId,
 			objectId,
 			cancellationToken);
@@ -139,69 +130,25 @@ internal sealed class UpdateContactHubSpotCommandHandler : ICommandHandler<Updat
 			return result;
 		}
 
-		await FillOutContactAssociationsAsync(result.Value, cancellationToken);
-
-		await _unitOfWork
+		_unitOfWork
 			.ContactRepository
-			.CreateAsync(
-				result.Value,
-				cancellationToken);
+			.Attach(result.Value);
 
 		await _unitOfWork.SaveAsync(cancellationToken);
 
 		return Result.Success();
 	}
 
-	private async Task<Contact> FillOutContactAssociationsAsync(
-		Contact contact,
-		CancellationToken cancellationToken = default)
-	{
-		List<Deal> deals = new();
-
-		foreach (DealContact dealContact in contact.DealContacts)
-		{
-			Deal? deal = await _unitOfWork
-				.DealRepository
-				.FirstOrDefaultAsync(
-					d => d.SourceId == dealContact.Deal.SourceId && d.Source == Sources.HubSpot,
-					cancellationToken);
-
-			if (deal is not null)
-			{
-				deals.Add(deal);
-			}
-		}
-
-		List<Client> clients = new();
-
-		foreach (ClientContact clientContact in contact.ClientContacts)
-		{
-			Client? client = await _unitOfWork
-				.ClientRepository
-				.FirstOrDefaultAsync(
-					c => c.SourceId == clientContact.Client.SourceId && c.Source == Sources.HubSpot,
-					cancellationToken);
-
-			if (client is not null)
-			{
-				clients.Add(client);
-			}
-		}
-
-		contact.FillOutAssociations(clients, deals);
-
-		return contact;
-	}
-
-	private async Task<Result<Contact>> GetContactFromHubSpot(
+	private async Task<Result<Contact>> GetContactFromHubSpotAsync(
 		long supplierHubSpotId,
 		long objectId,
 		CancellationToken cancellationToken = default)
 	{
-		Result<string> accessTokenResult = await _hubSpotAuthorizationService.RefreshAccessTokenFromSupplierHubSpotIdAsync(
-			supplierHubSpotId,
-			_unitOfWork,
-			cancellationToken);
+		Result<string> accessTokenResult = await _hubSpotAuthorizationService
+			.RefreshAccessTokenFromSupplierHubSpotIdAsync(
+				supplierHubSpotId,
+				_unitOfWork,
+				cancellationToken);
 
 		if (accessTokenResult.IsFailure)
 		{

--- a/src/Pelican.Domain/Entities/ClientContact.cs
+++ b/src/Pelican.Domain/Entities/ClientContact.cs
@@ -33,7 +33,7 @@ public class ClientContact : Entity, ITimeTracked
 	[GraphQLIgnore]
 	public static ClientContact Create(Client client, Contact contact)
 	{
-		return new(Guid.NewGuid())
+		return new()
 		{
 			Client = client,
 			ClientId = client.Id,

--- a/src/Pelican.Domain/Entities/Contact.cs
+++ b/src/Pelican.Domain/Entities/Contact.cs
@@ -125,8 +125,8 @@ public class Contact : Entity, ITimeTracked
 
 		foreach (DealContact dealContact in DealContacts.Where(dc => dc.IsActive))
 		{
-			if (!currentDealContacts.Any(currentDealContact => currentDealContact.SourceContactId == dealContact.SourceContactId
-			&& currentDealContact.Contact.Source == dealContact.Contact.Source))
+			if (!currentDealContacts.Any(currentDealContact => currentDealContact.SourceDealId == dealContact.SourceDealId
+			&& currentDealContact.Deal.Source == Source))
 			{
 				dealContact.Deactivate();
 			}
@@ -134,9 +134,9 @@ public class Contact : Entity, ITimeTracked
 
 		foreach (DealContact dealContact in currentDealContacts)
 		{
-			if (!DealContacts.Any(dc => dc.SourceContactId == dealContact.SourceContactId
+			if (!DealContacts.Any(dc => dc.SourceDealId == dealContact.SourceDealId
 			&& dc.IsActive
-			&& dc.Contact.Source == dealContact.Contact.Source))
+			&& Source == dealContact.Deal.Source))
 			{
 				DealContacts.Add(dealContact);
 			}

--- a/src/Pelican.Infrastructure.HubSpot/Mapping/Contacts/ContactResponseToContact.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Mapping/Contacts/ContactResponseToContact.cs
@@ -1,4 +1,5 @@
-﻿using Pelican.Domain;
+﻿using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Domain;
 using Pelican.Domain.Entities;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Contacts;
 
@@ -6,14 +7,17 @@ namespace Pelican.Infrastructure.HubSpot.Mapping.Contacts;
 
 internal static class ContactResponseToContact
 {
-	internal static Contact ToContact(this ContactResponse response)
+	public static Task<Contact> ToContact(
+		this ContactResponse response,
+		IUnitOfWork unitOfWork,
+		CancellationToken cancellationToken)
 	{
 		if (string.IsNullOrWhiteSpace(response.Properties.HubSpotObjectId))
 		{
 			throw new ArgumentNullException(nameof(response));
 		}
 
-		Contact result = new(Guid.NewGuid())
+		Contact result = new()
 		{
 			FirstName = response.Properties.FirstName,
 			LastName = response.Properties.LastName,
@@ -25,36 +29,32 @@ internal static class ContactResponseToContact
 			Source = Sources.HubSpot,
 		};
 
-		result.ClientContacts = response
+		result.SetClientContacts(response
 			.Associations
 			.Companies
 			.AssociationList
 			.Where(association => association.Type == "contact_to_company")
-			.Select(association => new ClientContact(Guid.NewGuid())
-			{
-				ContactId = result.Id,
-				SourceContactId = result.SourceId,
-				Contact = result,
-				IsActive = true,
-				SourceClientId = association.Id,
-			})
-			.ToList();
+			.Select(async association => await unitOfWork
+				.ClientRepository
+				.FirstOrDefaultAsync(
+					c => c.SourceId == association.Id
+						&& c.Source == Sources.HubSpot,
+					cancellationToken))
+			.Select(t => t.Result));
 
-		result.DealContacts = response
+		result.SetDealContacts(response
 			.Associations
 			.Deals
 			.AssociationList
 			.Where(association => association.Type == "contact_to_deal")
-			.Select(association => new DealContact(Guid.NewGuid())
-			{
-				Contact = result,
-				ContactId = result.Id,
-				SourceContactId = result.SourceId,
-				SourceDealId = association.Id,
-				IsActive = true,
-			})
-			.ToList();
+			.Select(async association => await unitOfWork
+				.DealRepository
+				.FirstOrDefaultAsync(
+					d => d.SourceId == association.Id
+						&& d.Source == Sources.HubSpot,
+					cancellationToken))
+			.Select(t => t.Result));
 
-		return result;
+		return Task.FromResult(result);
 	}
 }

--- a/src/Pelican.Infrastructure.HubSpot/Mapping/Contacts/ContactsResponseToContacts.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Mapping/Contacts/ContactsResponseToContacts.cs
@@ -1,11 +1,15 @@
-﻿using Pelican.Domain.Entities;
+﻿using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Domain.Entities;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Contacts;
 
 namespace Pelican.Infrastructure.HubSpot.Mapping.Contacts;
 
 internal static class ContactsResponseToContacts
 {
-	internal static List<Contact> ToContacts(this ContactsResponse responses)
+	internal static async Task<List<Contact>> ToContacts(
+		this ContactsResponse responses,
+		IUnitOfWork unitOfWork,
+		CancellationToken cancellationToken)
 	{
 		if (responses.Results is null)
 		{
@@ -16,7 +20,7 @@ internal static class ContactsResponseToContacts
 
 		foreach (ContactResponse response in responses.Results)
 		{
-			Contact result = response.ToContact();
+			Contact result = await response.ToContact(unitOfWork, cancellationToken);
 			results.Add(result);
 		}
 

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotContactService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotContactService.cs
@@ -1,4 +1,5 @@
-﻿using Pelican.Application.Abstractions.HubSpot;
+﻿using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.Abstractions.HubSpot;
 using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
@@ -12,10 +13,14 @@ namespace Pelican.Infrastructure.HubSpot.Services;
 
 internal sealed class HubSpotContactService : ServiceBase<HubSpotSettings>, IHubSpotObjectService<Contact>
 {
+	private readonly IUnitOfWork _unitOfWork;
+
 	public HubSpotContactService(
-		IClient<HubSpotSettings> hubSpotClient)
+		IClient<HubSpotSettings> hubSpotClient,
+		IUnitOfWork unitOfWork)
 		: base(hubSpotClient)
-	{ }
+		=> _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+
 
 	public async Task<Result<Contact>> GetByIdAsync(
 		string accessToken,
@@ -29,8 +34,11 @@ internal sealed class HubSpotContactService : ServiceBase<HubSpotSettings>, IHub
 		IResponse<ContactResponse> response = await _client
 			.GetAsync<ContactResponse>(request, cancellationToken);
 
-		return response
-			.GetResult(ContactResponseToContact.ToContact);
+		return await response
+			.GetResultWithUnitOfWork(
+				ContactResponseToContact.ToContact,
+				_unitOfWork,
+				cancellationToken);
 	}
 
 	public async Task<Result<List<Contact>>> GetAsync(
@@ -44,7 +52,10 @@ internal sealed class HubSpotContactService : ServiceBase<HubSpotSettings>, IHub
 		IResponse<ContactsResponse> response = await _client
 			.GetAsync<ContactsResponse>(request, cancellationToken);
 
-		return response
-			.GetResult(ContactsResponseToContacts.ToContacts);
+		return await response
+			.GetResultWithUnitOfWork(
+				ContactsResponseToContacts.ToContacts,
+				_unitOfWork,
+				cancellationToken);
 	}
 }

--- a/test/Pelican.Domain.Test/Entities/ContactTests.cs
+++ b/test/Pelican.Domain.Test/Entities/ContactTests.cs
@@ -7,7 +7,7 @@ namespace Pelican.Domain.Test.Entities;
 
 public class ContactTests
 {
-	private readonly Contact _uut = new Contact(Guid.NewGuid())
+	private readonly Contact _uut = new()
 	{
 		SourceId = "uutHubSpotId",
 		Source = Sources.HubSpot,
@@ -101,7 +101,7 @@ public class ContactTests
 		// Assert
 
 		Assert.Equal(StringLengths.Name, _uut.FirstName!.Length);
-		Assert.Equal(propertyValue.Substring(0, StringLengths.Name - 3) + "...", _uut.FirstName);
+		Assert.Equal(propertyValue[..(StringLengths.Name - 3)] + "...", _uut.FirstName);
 	}
 
 	[Fact]
@@ -116,7 +116,7 @@ public class ContactTests
 
 		// Assert
 		Assert.Equal(StringLengths.Name, _uut.LastName!.Length);
-		Assert.Equal(propertyValue.Substring(0, StringLengths.Name - 3) + "...", _uut.LastName);
+		Assert.Equal(propertyValue[..(StringLengths.Name - 3)] + "...", _uut.LastName);
 	}
 
 	[Fact]
@@ -131,7 +131,7 @@ public class ContactTests
 
 		// Assert
 		Assert.Equal(StringLengths.Email, _uut.Email!.Length);
-		Assert.Equal(propertyValue.Substring(0, StringLengths.Email - 3) + "...", _uut.Email);
+		Assert.Equal(propertyValue[..(StringLengths.Email - 3)] + "...", _uut.Email);
 	}
 
 	[Fact]
@@ -146,7 +146,7 @@ public class ContactTests
 
 		// Assert
 		Assert.Equal(StringLengths.PhoneNumber, _uut.PhoneNumber!.Length);
-		Assert.Equal(propertyValue.Substring(0, StringLengths.PhoneNumber - 3) + "...", _uut.PhoneNumber);
+		Assert.Equal(propertyValue[..(StringLengths.PhoneNumber - 3)] + "...", _uut.PhoneNumber);
 	}
 
 	[Fact]
@@ -161,7 +161,7 @@ public class ContactTests
 
 		// Assert
 		Assert.Equal(StringLengths.JobTitle, _uut.JobTitle!.Length);
-		Assert.Equal(propertyValue.Substring(0, StringLengths.JobTitle - 3) + "...", _uut.JobTitle);
+		Assert.Equal(propertyValue[..(StringLengths.JobTitle - 3)] + "...", _uut.JobTitle);
 	}
 
 	[Fact]
@@ -294,8 +294,8 @@ public class ContactTests
 		// Assert
 
 		Assert.Equal(StringLengths.Name, _uut.FirstName!.Length);
-		Assert.Equal("...", _uut.FirstName.Substring(StringLengths.Name - 3));
-		Assert.Equal(propertyValue.Substring(0, StringLengths.Name - 3), _uut.FirstName.Substring(0, StringLengths.Name - 3));
+		Assert.Equal("...", _uut.FirstName[(StringLengths.Name - 3)..]);
+		Assert.Equal(propertyValue[..(StringLengths.Name - 3)], _uut.FirstName[..(StringLengths.Name - 3)]);
 	}
 
 	[Fact]
@@ -311,8 +311,8 @@ public class ContactTests
 
 		// Assert
 		Assert.Equal(StringLengths.Name, _uut.LastName!.Length);
-		Assert.Equal("...", _uut.LastName.Substring(StringLengths.Name - 3));
-		Assert.Equal(propertyValue.Substring(0, StringLengths.Name - 3), _uut.LastName.Substring(0, StringLengths.Name - 3));
+		Assert.Equal("...", _uut.LastName[(StringLengths.Name - 3)..]);
+		Assert.Equal(propertyValue[..(StringLengths.Name - 3)], _uut.LastName[..(StringLengths.Name - 3)]);
 	}
 
 	[Fact]
@@ -328,8 +328,8 @@ public class ContactTests
 
 		// Assert
 		Assert.Equal(StringLengths.Email, _uut.Email!.Length);
-		Assert.Equal("...", _uut.Email.Substring(StringLengths.Email - 3));
-		Assert.Equal(propertyValue.Substring(0, StringLengths.Email - 3), _uut.Email.Substring(0, StringLengths.Email - 3));
+		Assert.Equal("...", _uut.Email[(StringLengths.Email - 3)..]);
+		Assert.Equal(propertyValue[..(StringLengths.Email - 3)], _uut.Email[..(StringLengths.Email - 3)]);
 	}
 
 	[Fact]
@@ -345,8 +345,8 @@ public class ContactTests
 
 		// Assert
 		Assert.Equal(StringLengths.PhoneNumber, _uut.PhoneNumber!.Length);
-		Assert.Equal("...", _uut.PhoneNumber.Substring(StringLengths.PhoneNumber - 3));
-		Assert.Equal(propertyValue.Substring(0, StringLengths.PhoneNumber - 3), _uut.PhoneNumber.Substring(0, StringLengths.PhoneNumber - 3));
+		Assert.Equal("...", _uut.PhoneNumber[(StringLengths.PhoneNumber - 3)..]);
+		Assert.Equal(propertyValue[..(StringLengths.PhoneNumber - 3)], _uut.PhoneNumber[..(StringLengths.PhoneNumber - 3)]);
 	}
 
 	[Fact]
@@ -362,8 +362,8 @@ public class ContactTests
 
 		// Assert
 		Assert.Equal(StringLengths.PhoneNumber, _uut.PhoneNumber!.Length);
-		Assert.Equal("...", _uut.PhoneNumber.Substring(StringLengths.PhoneNumber - 3));
-		Assert.Equal(propertyValue.Substring(0, StringLengths.PhoneNumber - 3), _uut.PhoneNumber.Substring(0, StringLengths.PhoneNumber - 3));
+		Assert.Equal("...", _uut.PhoneNumber[(StringLengths.PhoneNumber - 3)..]);
+		Assert.Equal(propertyValue[..(StringLengths.PhoneNumber - 3)], _uut.PhoneNumber[..(StringLengths.PhoneNumber - 3)]);
 	}
 
 	[Fact]
@@ -379,8 +379,8 @@ public class ContactTests
 
 		// Assert
 		Assert.Equal(StringLengths.JobTitle, _uut.JobTitle!.Length);
-		Assert.Equal("...", _uut.JobTitle.Substring(StringLengths.JobTitle - 3));
-		Assert.Equal(propertyValue.Substring(0, StringLengths.JobTitle - 3), _uut.JobTitle.Substring(0, StringLengths.JobTitle - 3));
+		Assert.Equal("...", _uut.JobTitle[(StringLengths.JobTitle - 3)..]);
+		Assert.Equal(propertyValue[..(StringLengths.JobTitle - 3)], _uut.JobTitle[..(StringLengths.JobTitle - 3)]);
 	}
 
 	[Fact]
@@ -530,178 +530,6 @@ public class ContactTests
 			.IsActive);
 	}
 
-	[Fact]
-	public void FillOutAssociations_ClientsAndDealsNull_ThrowNoExceptionEmptyClientContacts()
-	{
-		// Act
-		var result = Record.Exception(() => _uut.FillOutAssociations(null, null));
-
-		// Assert
-		Assert.Null(result);
-
-		Assert.Empty(_uut.ClientContacts);
-	}
-
-	[Fact]
-	public void FillOutAssociations_ClientsEmpty_EmptyClientContacts()
-	{
-		// Act
-		_uut.FillOutAssociations(Enumerable.Empty<Client>(), null);
-
-		// Assert
-		Assert.Empty(_uut.ClientContacts);
-	}
-
-	[Fact]
-	public void FillOutAssociations_ExistingClientNotMatchingArgument_EmptyClientContacts()
-	{
-		// Arrange
-		ClientContact existingClientContact = new(Guid.NewGuid())
-		{
-			SourceClientId = "hsID",
-			Contact = _uut,
-			ContactId = _uut.Id,
-			SourceContactId = _uut.SourceId,
-			IsActive = true,
-		};
-
-		_uut.ClientContacts.Add(existingClientContact);
-
-		Client newClient = new(Guid.NewGuid())
-		{
-			SourceId = "another_hsId",
-		};
-
-		// Act
-		_uut.FillOutAssociations(new List<Client>() { newClient }, null);
-
-		// Assert
-		Assert.Empty(_uut.ClientContacts);
-	}
-
-	[Fact]
-	public void FillOutAssociations_ExistingClientMatchingArgument_ClientContactsUpdated()
-	{
-		// Arrange
-		ClientContact existingClientContact = new(Guid.NewGuid())
-		{
-			SourceClientId = "hsID",
-			Contact = _uut,
-			ContactId = _uut.Id,
-			SourceContactId = _uut.SourceId,
-			IsActive = true,
-		};
-
-		_uut.ClientContacts.Add(existingClientContact);
-
-		Client newClient = new(Guid.NewGuid())
-		{
-			SourceId = "hsID",
-			Source = Sources.HubSpot,
-		};
-
-		// Act
-		_uut.FillOutAssociations(new List<Client>() { newClient }, null);
-
-		// Assert
-		Assert.Equal(
-			1,
-			_uut.ClientContacts.Count);
-
-		Assert.Equal(
-			newClient,
-			_uut.ClientContacts.First().Client);
-
-		Assert.Equal(
-			newClient.Id,
-			_uut.ClientContacts.First().ClientId);
-	}
-
-	[Fact]
-	public void FillOutAssociations_DealsNull_EmptyDealContacts()
-	{
-		// Act
-		_uut.FillOutAssociations(null, null);
-
-		// Assert
-		Assert.Empty(_uut.DealContacts);
-	}
-
-	[Fact]
-	public void FillOutAssociations_DealsEmpty_EmptyDealContacts()
-	{
-		// Act
-		_uut.FillOutAssociations(null, Enumerable.Empty<Deal>());
-
-		// Assert
-		Assert.Empty(_uut.DealContacts);
-	}
-
-	[Fact]
-	public void FillOutAssociations_ExistingDealNotMatchingArgument_EmptyDealContacts()
-	{
-		// Arrange
-		DealContact existingDealContact = new(Guid.NewGuid())
-		{
-			SourceDealId = "hsID",
-			Contact = _uut,
-			ContactId = _uut.Id,
-			SourceContactId = _uut.SourceId,
-			IsActive = true,
-		};
-
-		_uut.DealContacts.Add(existingDealContact);
-
-		Deal newDeal = new(Guid.NewGuid())
-		{
-			SourceId = "another_hsId",
-		};
-
-		// Act
-		_uut.FillOutAssociations(null, new List<Deal>() { newDeal });
-
-		// Assert
-		Assert.Empty(_uut.DealContacts);
-	}
-
-	[Fact]
-	public void FillOutAssociations_ExistingDealMatchingArgument_DealContactsUpdated()
-	{
-		// Arrange
-		DealContact existingDealContact = new(Guid.NewGuid())
-		{
-			SourceDealId = "hsID",
-			Contact = _uut,
-			ContactId = _uut.Id,
-			SourceContactId = _uut.SourceId,
-			IsActive = true,
-		};
-
-		_uut.DealContacts.Add(existingDealContact);
-
-		Deal newDeal = new(Guid.NewGuid())
-		{
-			SourceId = "hsID",
-			Source = Sources.HubSpot,
-		};
-
-		// Act
-		_uut.FillOutAssociations(null, new List<Deal>() { newDeal });
-
-		// Assert
-		Assert.Equal(
-			1,
-			_uut.DealContacts.Count);
-
-		Assert.Equal(
-			newDeal,
-			_uut.DealContacts.First().Deal);
-
-		Assert.Equal(
-			newDeal.Id,
-			_uut.DealContacts.First().DealId);
-	}
-
 	[Theory]
 	[InlineData("testFirstName", "testLastName", "testEmail", "testPhoneNumber", "testJobTitle")]
 	public void UpdatePropertiesFromContact_PropertiesSet(string testFirstName, string testLastName, string testEmail, string testPhoneNumber, string testJobtTitle)
@@ -723,5 +551,117 @@ public class ContactTests
 		Assert.Equal(testEmail, _uut.Email);
 		Assert.Equal(testPhoneNumber, _uut.PhoneNumber);
 		Assert.Equal(testJobtTitle, _uut.JobTitle);
+	}
+
+	[Fact]
+	public void SetDealContacts_ArgsNull_DealContactsEmpty()
+	{
+		// Arrange
+		Contact input = new();
+
+		// Act
+		input.SetDealContacts(null);
+
+		// Assert
+		Assert.Empty(input.DealContacts);
+	}
+
+	[Fact]
+	public void SetDealContacts_ArgsEmptyList_DealContactsEmpty()
+	{
+		// Arrange
+		Contact input = new();
+
+		// Act
+		input.SetDealContacts(new List<Deal>());
+
+		// Assert
+		Assert.Empty(input.DealContacts);
+	}
+
+	[Fact]
+	public void SetDealContacts_ArgsNonEmptyList_DealContactsSet()
+	{
+		// Arrange
+		Contact input = new();
+
+		// Act
+		input.SetDealContacts(new List<Deal>() { new() });
+
+		// Assert
+		Assert.Equal(
+			1,
+			input.DealContacts.Count);
+	}
+
+	[Fact]
+	public void SetDealContacts_ArgsListContainingNull_DealContactsSet()
+	{
+		// Arrange
+		Contact input = new();
+
+		// Act
+		input.SetDealContacts(new List<Deal?>() { new(), null });
+
+		// Assert
+		Assert.Equal(
+			1,
+			input.DealContacts.Count);
+	}
+
+	[Fact]
+	public void SetClientContacts_ArgsNull_ClientContactsEmpty()
+	{
+		// Arrange
+		Contact input = new();
+
+		// Act
+		input.SetClientContacts(null);
+
+		// Assert
+		Assert.Empty(input.ClientContacts);
+	}
+
+	[Fact]
+	public void SetClientContacts_ArgsEmptyList_ClientContactsEmpty()
+	{
+		// Arrange
+		Contact input = new();
+
+		// Act
+		input.SetClientContacts(new List<Client>());
+
+		// Assert
+		Assert.Empty(input.ClientContacts);
+	}
+
+	[Fact]
+	public void SetClientContacts_ArgsNonEmptyList_ClientContactsSet()
+	{
+		// Arrange
+		Contact input = new();
+
+		// Act
+		input.SetClientContacts(new List<Client>() { new() });
+
+		// Assert
+		Assert.Equal(
+			1,
+			input.ClientContacts.Count);
+	}
+
+	[Fact]
+	public void SetClientContacts_ArgsListContainingNull_ClientContactsSet()
+	{
+		// Arrange
+		Contact input = new();
+
+		// Act
+		input.SetClientContacts(new List<Client?>() { new(), null });
+
+		// Assert
+		Assert.Equal(
+			1,
+			input.ClientContacts.Count);
 	}
 }

--- a/test/Pelican.Infrastructure.HubSpot.Test/Mapping/Contacts/ContactResponseToContactTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Mapping/Contacts/ContactResponseToContactTests.cs
@@ -1,4 +1,7 @@
-﻿using Bogus;
+﻿using System.Linq.Expressions;
+using Bogus;
+using Moq;
+using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Domain;
 using Pelican.Domain.Entities;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
@@ -18,6 +21,8 @@ public class ContactResponseToContactTests
 	private const string JOBTITLE = "jobtitle";
 	private const string OWNERID = "ownerid";
 
+	private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+
 	private readonly ContactResponse response = new()
 	{
 		Properties = new()
@@ -33,14 +38,14 @@ public class ContactResponseToContactTests
 	};
 
 	[Fact]
-	public void ToContact_ResponseMissingHubSpotId_ThrowsException()
+	public async Task ToContact_ResponseMissingHubSpotId_ThrowsException()
 	{
 		/// Arrange
 		ContactResponse defaultResponse = new();
 		defaultResponse.Properties.HubSpotOwnerId = OWNERID;
 
 		/// Act
-		Exception result = Record.Exception(() => defaultResponse.ToContact());
+		Exception result = await Record.ExceptionAsync(() => defaultResponse.ToContact(_unitOfWorkMock.Object, default));
 
 		/// Assert
 		Assert.NotNull(result);
@@ -51,10 +56,10 @@ public class ContactResponseToContactTests
 	}
 
 	[Fact]
-	public void ToContact_WithoutAssociations_ReturnCorrectProperties()
+	public async Task ToContact_WithoutAssociations_ReturnCorrectPropertiesAndAssociations()
 	{
 		/// Act
-		Contact result = response.ToContact();
+		Contact result = await response.ToContact(_unitOfWorkMock.Object, default);
 
 		/// Assert
 		Assert.Equal(FIRSTNAME, result.FirstName);
@@ -65,62 +70,35 @@ public class ContactResponseToContactTests
 		Assert.Equal(JOBTITLE, result.JobTitle);
 		Assert.Equal(OWNERID, result.SourceOwnerId);
 		Assert.Equal(Sources.HubSpot, result.Source);
-	}
 
-	[Fact]
-	public void ToContact_WithoutAssociations_ReturnContactWithEmptyDealContacts()
-	{
-		/// Act
-		Contact result = response.ToContact();
-
-		/// Assert
 		Assert.Equal(0, result.DealContacts!.Count);
-	}
-
-	[Fact]
-	public void ToContact_WithoutAssociations_ReturnContactWithEmptyClientContacts()
-	{
-		/// Act
-		Contact result = response.ToContact();
-
-		/// Assert
 		Assert.Equal(0, result.ClientContacts!.Count);
 	}
 
 	[Fact]
-	public void ToContact_WithDefaultDeals_ReturnContactEmptyDealContacts()
+	public async Task ToContact_WithDefaultDeals_ReturnContactEmptyDealContactsAndEmptyClientContacts()
 	{
 		/// Arrange
 		response.Associations.Deals.AssociationList = new List<Association>()
 		{
 			new(),
 		};
-
-		/// Act
-		Contact result = response.ToContact();
-
-		/// Assert
-		Assert.Equal(0, result.DealContacts!.Count);
-	}
-
-	[Fact]
-	public void ToContact_WithDefaultCompanies_ReturnContactEmptyClientContacts()
-	{
-		/// Arrange
 		response.Associations.Companies.AssociationList = new List<Association>()
 		{
 			new(),
 		};
 
+
 		/// Act
-		Contact result = response.ToContact();
+		Contact result = await response.ToContact(_unitOfWorkMock.Object, default);
 
 		/// Assert
+		Assert.Equal(0, result.DealContacts!.Count);
 		Assert.Equal(0, result.ClientContacts!.Count);
 	}
 
 	[Fact]
-	public void ToContact_WithNotMatchingAssociations_ReturnContactEmptyDealContacts()
+	public async Task ToContact_WithNotMatchingAssociations_ReturnContactEmptyDealContacts()
 	{
 		/// Arrange
 		response.Associations.Deals.AssociationList = new List<Association>()
@@ -133,14 +111,14 @@ public class ContactResponseToContactTests
 		};
 
 		/// Act
-		Contact result = response.ToContact();
+		Contact result = await response.ToContact(_unitOfWorkMock.Object, default);
 
 		/// Assert
 		Assert.Equal(0, result.DealContacts!.Count);
 	}
 
 	[Fact]
-	public void ToContact_WithNotMatchingAssociations_ReturnContactEmptyClientContacts()
+	public async Task ToContact_WithNotMatchingAssociations_ReturnContactEmptyClientContacts()
 	{
 		/// Arrange
 		response.Associations.Companies.AssociationList = new List<Association>()
@@ -153,14 +131,14 @@ public class ContactResponseToContactTests
 		};
 
 		/// Act
-		Contact result = response.ToContact();
+		Contact result = await response.ToContact(_unitOfWorkMock.Object, default);
 
 		/// Assert
 		Assert.Equal(0, result.ClientContacts!.Count);
 	}
 
 	[Fact]
-	public void ToContact_WithMatchingAssociations_ReturnContactWithDeals()
+	public async Task ToContact_WithMatchingAssociations_ReturnContactWithDeals()
 	{
 		/// Arrange
 		response.Associations.Deals.AssociationList = new List<Association>()
@@ -172,8 +150,16 @@ public class ContactResponseToContactTests
 			},
 		};
 
+		_unitOfWorkMock
+			.Setup(u => u
+				.DealRepository
+				.FirstOrDefaultAsync(
+					It.IsAny<Expression<Func<Deal, bool>>>(),
+					It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new Deal() { SourceId = "1" });
+
 		/// Act
-		Contact result = response.ToContact();
+		Contact result = await response.ToContact(_unitOfWorkMock.Object, default);
 
 		/// Assert
 		Assert.Equal(1, result.DealContacts!.Count);
@@ -183,82 +169,7 @@ public class ContactResponseToContactTests
 	}
 
 	[Fact]
-	public void ToContact_FirstNameStringTooLong_FirstNameShortenededAndAppendedWithThreeDots()
-	{
-		Faker faker = new();
-		response.Properties.FirstName = faker.Lorem.Letter(StringLengths.Name * 2);
-
-		/// Act
-		Contact result = response.ToContact();
-
-		/// Assert
-		Assert.Equal(StringLengths.Name, result.FirstName!.Length);
-		Assert.Equal("...", result.FirstName.Substring(StringLengths.Name - 3));
-		Assert.Equal(response.Properties.FirstName.Substring(0, StringLengths.Name - 3), result.FirstName.Substring(0, StringLengths.Email - 3));
-	}
-
-	[Fact]
-	public void ToContact_LastNameStringTooLong_LastNameShortenededAndAppendedWithThreeDots()
-	{
-		Faker faker = new();
-		response.Properties.LastName = faker.Lorem.Letter(StringLengths.Name * 2);
-
-		/// Act
-		Contact result = response.ToContact();
-
-		/// Assert
-		Assert.Equal(StringLengths.Name, result.LastName!.Length);
-		Assert.Equal("...", result.LastName.Substring(StringLengths.Name - 3));
-		Assert.Equal(response.Properties.LastName.Substring(0, StringLengths.Name - 3), result.LastName.Substring(0, StringLengths.Name - 3));
-	}
-
-	[Fact]
-	public void ToContact_EmailStringTooLong_EmailShortenededAndAppendedWithThreeDots()
-	{
-		Faker faker = new();
-		response.Properties.Email = faker.Lorem.Letter(StringLengths.Email * 2);
-
-		/// Act
-		Contact result = response.ToContact();
-
-		/// Assert
-		Assert.Equal(StringLengths.Email, result.Email!.Length);
-		Assert.Equal("...", result.Email.Substring(StringLengths.Email - 3));
-		Assert.Equal(response.Properties.Email.Substring(0, StringLengths.Email - 3), result.Email.Substring(0, StringLengths.Email - 3));
-	}
-
-	[Fact]
-	public void ToContact_PhoneStringTooLong_PhoneShortenededAndAppendedWithThreeDots()
-	{
-		Faker faker = new();
-		response.Properties.Phone = faker.Lorem.Letter(StringLengths.PhoneNumber * 2);
-
-		/// Act
-		Contact result = response.ToContact();
-
-		/// Assert
-		Assert.Equal(StringLengths.PhoneNumber, result.PhoneNumber!.Length);
-		Assert.Equal("...", result.PhoneNumber.Substring(StringLengths.PhoneNumber - 3));
-		Assert.Equal(response.Properties.Phone.Substring(0, StringLengths.PhoneNumber - 3), result.PhoneNumber.Substring(0, StringLengths.PhoneNumber - 3));
-	}
-
-	[Fact]
-	public void ToContact_JobTitleStringTooLong_JobTitleShortenededAndAppendedWithThreeDots()
-	{
-		Faker faker = new();
-		response.Properties.JobTitle = faker.Lorem.Letter(StringLengths.JobTitle * 2);
-
-		/// Act
-		Contact result = response.ToContact();
-
-		/// Assert
-		Assert.Equal(StringLengths.JobTitle, result.JobTitle!.Length);
-		Assert.Equal("...", result.JobTitle.Substring(StringLengths.JobTitle - 3));
-		Assert.Equal(response.Properties.JobTitle.Substring(0, StringLengths.JobTitle - 3), result.JobTitle.Substring(0, StringLengths.JobTitle - 3));
-	}
-
-	[Fact]
-	public void ToContact_WithMatchingAssociations_ReturnContactWithClientContacts()
+	public async Task ToContact_WithMatchingAssociations_ReturnContactWithClientContacts()
 	{
 		/// Arrange
 		response.Associations.Companies.AssociationList = new List<Association>()
@@ -270,8 +181,16 @@ public class ContactResponseToContactTests
 			},
 		};
 
+		_unitOfWorkMock
+			.Setup(u => u
+				.ClientRepository
+				.FirstOrDefaultAsync(
+					It.IsAny<Expression<Func<Client, bool>>>(),
+					It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new Client() { SourceId = "1" });
+
 		/// Act
-		Contact result = response.ToContact();
+		Contact result = await response.ToContact(_unitOfWorkMock.Object, default);
 
 		/// Assert
 		Assert.Equal(1, result.ClientContacts!.Count);

--- a/test/Pelican.Infrastructure.HubSpot.Test/Mapping/Contacts/ContactsResponseToContactsTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Mapping/Contacts/ContactsResponseToContactsTests.cs
@@ -1,4 +1,6 @@
-﻿using Pelican.Domain;
+﻿using Moq;
+using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Domain;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Contacts;
 using Pelican.Infrastructure.HubSpot.Mapping.Contacts;
 using Xunit;
@@ -9,6 +11,8 @@ public class ContactsResponseToContactsTests
 {
 	const string ID = "id";
 	const string OWNERID = "ownerid";
+
+	private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
 
 	readonly ContactResponse response = new()
 	{
@@ -22,13 +26,13 @@ public class ContactsResponseToContactsTests
 	readonly ContactsResponse responses = new();
 
 	[Fact]
-	public void ToContacts_ArgResultsNull_ThrowException()
+	public async Task ToContacts_ArgResultsNull_ThrowExceptionAsync()
 	{
 		/// Arrange
 		responses.Results = null!;
 
 		/// Act
-		var result = Record.Exception(() => responses.ToContacts());
+		var result = await Record.ExceptionAsync(() => responses.ToContacts(_unitOfWorkMock.Object, default));
 
 		/// Assert
 		Assert.NotNull(result);
@@ -39,39 +43,39 @@ public class ContactsResponseToContactsTests
 	}
 
 	[Fact]
-	public void ToContacts_ArgResultsNotNull_ThrowNoException()
+	public async Task ToContacts_ArgResultsNotNull_ThrowNoExceptionAsync()
 	{
 		/// Arrange 
 		responses.Results = new List<ContactResponse>();
 
 		/// Act
-		var result = Record.Exception(() => responses.ToContacts());
+		var result = await Record.ExceptionAsync(() => responses.ToContacts(_unitOfWorkMock.Object, default));
 
 		/// Assert
 		Assert.Null(result);
 	}
 
 	[Fact]
-	public void ToContacts_ArgResultsNotNullNotEmpty_ThrowNoException()
+	public async Task ToContacts_ArgResultsNotNullNotEmpty_ThrowNoExceptionAsync()
 	{
 		/// Arrange 
 		responses.Results = new List<ContactResponse>() { response };
 
 		/// Act
-		var result = Record.Exception(() => responses.ToContacts());
+		var result = await Record.ExceptionAsync(() => responses.ToContacts(_unitOfWorkMock.Object, default));
 
 		/// Assert
 		Assert.Null(result);
 	}
 
 	[Fact]
-	public void ToContacts_SingleResponse_ReturnSingle()
+	public async void ToContacts_SingleResponse_ReturnSingle()
 	{
 		/// Arrange
 		responses.Results = new List<ContactResponse>() { response };
 
 		/// Act
-		var result = responses.ToContacts();
+		var result = await responses.ToContacts(_unitOfWorkMock.Object, default);
 
 		/// Assert
 		Assert.Equal(ID, result.First().SourceId);


### PR DESCRIPTION
Formål: Få HubSpot opdateringer for Contacts til at virke og gør handleren til dette mindre kompleks

Infrastructure.HubSpot: Har givet mapperen adgang til databasen, så eksisterende associationer kan kobles på. 
Application: Den nye mapper har gjort handleren mere simpel, hvorfor der er slettet en masse herfra, da databasen skal kaldes mindre. 
Domain: Contact klassen er ændret, så "FillOut..." funktionerne er fjernet og erstattet med Set og UpdateMetoder. Derudover er der flyttet lidt rundt på properties og gjort dem kortere uden at ændre funktionaliteten. Derfor ligner det der er ændret mere end der reelt er..