### PR TITLE
Hotfix/make supplier on account manager non nullable again

### DIFF
--- a/src/Pelican.Domain/Entities/AccountManager.cs
+++ b/src/Pelican.Domain/Entities/AccountManager.cs
@@ -11,7 +11,9 @@ public class AccountManager : Entity, ITimeTracked
 
 	public AccountManager(Guid id) : base(id) { }
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 	public AccountManager() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
 	public string SourceId { get; set; } = string.Empty;
 

--- a/src/Pelican.Domain/Entities/AccountManager.cs
+++ b/src/Pelican.Domain/Entities/AccountManager.cs
@@ -77,7 +77,7 @@ public class AccountManager : Entity, ITimeTracked
 
 	public Guid SupplierId { get; set; }
 
-	public Supplier? Supplier { get; set; }
+	public Supplier Supplier { get; set; }
 
 	public ICollection<AccountManagerDeal> AccountManagerDeals { get; set; } = new List<AccountManagerDeal>();
 


### PR DESCRIPTION
Supplier is no longer nullable on AccountManager. We are now Suppressing the issue on the default constructor, the none default constructor is not suppressed but it is due to be removed soon.