### PR TITLE
Feature/plcn 296 remove picture url from client entity

### DIFF
--- a/src/Pelican.Application/Clients/PipedriveCommands/Update/UpdateClientPipedriveCommand.cs
+++ b/src/Pelican.Application/Clients/PipedriveCommands/Update/UpdateClientPipedriveCommand.cs
@@ -6,7 +6,6 @@ public sealed record UpdateClientPipedriveCommand(
 	int clientId,
 	int clientPipedriveOwnerId,
 	string clientName,
-	string? pictureUrl,
 	string? officeLocation,
 	string? website) : ICommand;
 

--- a/src/Pelican.Application/PelicanBogusFaker.cs
+++ b/src/Pelican.Application/PelicanBogusFaker.cs
@@ -71,7 +71,6 @@ public class PelicanBogusFaker : IPelicanBogusFaker
 		var faker = new Faker<Client>().UseSeed(1341);
 		faker
 			.RuleFor(e => e.Name, f => f.Company.CompanyName())
-			.RuleFor(e => e.PictureUrl, f => f.Image.PicsumUrl().OrNull(f, 0.0f))
 			.RuleFor(e => e.OfficeLocation, f => f.Address.City().OrNull(f, 0.0f))
 			.RuleFor(e => e.SourceId, f => f.Random.Guid().ToString())
 			.RuleFor(e => e.Website, f => f.Internet.Url().OrNull(f, 0.0f))

--- a/src/Pelican.Domain/Entities/Client.cs
+++ b/src/Pelican.Domain/Entities/Client.cs
@@ -7,8 +7,6 @@ public class Client : Entity, ITimeTracked
 	private string _name = string.Empty;
 	private string? _website { get; set; }
 
-	public string? PictureUrl { get; set; }
-
 	public Client(Guid id) : base(id) { }
 
 	public Client() { }

--- a/src/Pelican.Infrastructure.Persistence/Configurations/ClientConfiguration.cs
+++ b/src/Pelican.Infrastructure.Persistence/Configurations/ClientConfiguration.cs
@@ -14,9 +14,6 @@ internal class ClientConfiguration : IEntityTypeConfiguration<Client>
 			.HasMaxLength(StringLengths.Name)
 			.IsRequired();
 
-		builder.Property(p => p.PictureUrl)
-			.HasMaxLength(StringLengths.Url);
-
 		builder.Property(p => p.OfficeLocation)
 			.HasMaxLength(StringLengths.OfficeLocation);
 

--- a/src/Pelican.Infrastructure.Persistence/Migrations/20221215100841_PictureUrl-Removed-From-Client.Designer.cs
+++ b/src/Pelican.Infrastructure.Persistence/Migrations/20221215100841_PictureUrl-Removed-From-Client.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Pelican.Infrastructure.Persistence;
 
@@ -11,9 +12,10 @@ using Pelican.Infrastructure.Persistence;
 namespace Pelican.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(PelicanContext))]
-    partial class PelicanContextModelSnapshot : ModelSnapshot
+    [Migration("20221215100841_PictureUrl-Removed-From-Client")]
+    partial class PictureUrlRemovedFromClient
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Pelican.Infrastructure.Persistence/Migrations/20221215100841_PictureUrl-Removed-From-Client.cs
+++ b/src/Pelican.Infrastructure.Persistence/Migrations/20221215100841_PictureUrl-Removed-From-Client.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Pelican.Infrastructure.Persistence.Migrations
+{
+    public partial class PictureUrlRemovedFromClient : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PictureUrl",
+                table: "Clients");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PictureUrl",
+                table: "Clients",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: true);
+        }
+    }
+}

--- a/src/Pelican.Presentation.Api/Controllers/PipedriveController.cs
+++ b/src/Pelican.Presentation.Api/Controllers/PipedriveController.cs
@@ -87,7 +87,6 @@ public sealed class PipedriveController : ApiController
 			request.MetaProperties.ObjectId,
 			request.MetaProperties.UserId,
 			request.CurrentProperties.ClientName,
-			null,
 			request.CurrentProperties.OfficeLocation,
 			null
 			);

--- a/test/Pelican.Presentation.Api.Test/Controllers/PipedriveControllerUnitTest.cs
+++ b/test/Pelican.Presentation.Api.Test/Controllers/PipedriveControllerUnitTest.cs
@@ -432,7 +432,6 @@ public class PipedriveControllerUnitTest
 			objectId,
 			userId,
 			clientName,
-			null,
 			officeLocation,
 			null);
 


### PR DESCRIPTION
Property til PictureUrl er fjernet fra Client, da vi ikke har fundet en løsning til at hente billede og det er ikke en prioritet lige nu, så derfor blev propertien ikke brugt alligevel. 