### PR TITLE
manifest added with efcore and snitch

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "7.0.1",
+      "commands": [
+        "dotnet-ef"
+      ]
+    },
+    "snitch": {
+      "version": "1.12.0",
+      "commands": [
+        "snitch"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Added manifest to project to let developers use tool without installing them first. 
Dotnet Ef is for database access
Snitch lets u find redundant package imports 