### PR TITLE
Added IUnitOfWork to serviceBase

### DIFF
--- a/src/Pelican.Application/Abstractions/HubSpot/IHubSpotAuthorizationService.cs
+++ b/src/Pelican.Application/Abstractions/HubSpot/IHubSpotAuthorizationService.cs
@@ -1,5 +1,4 @@
-﻿using Pelican.Application.Abstractions.Data.Repositories;
-using Pelican.Application.HubSpot.Dtos;
+﻿using Pelican.Application.HubSpot.Dtos;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Shared;
 
@@ -10,7 +9,7 @@ public interface IHubSpotAuthorizationService
 
 	Task<Result<Supplier>> DecodeAccessTokenAsync(string accessToken, CancellationToken cancellationToken);
 
-	Task<Result<string>> RefreshAccessTokenFromSupplierHubSpotIdAsync(long supplierHubSpotId, IUnitOfWork unitOfWork, CancellationToken cancellationToken);
+	Task<Result<string>> RefreshAccessTokenFromSupplierHubSpotIdAsync(long supplierHubSpotId, CancellationToken cancellationToken);
 
 	Task<Result<string>> RefreshAccessTokenFromRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken);
 }

--- a/src/Pelican.Application/Abstractions/Infrastructure/ServiceBase.cs
+++ b/src/Pelican.Application/Abstractions/Infrastructure/ServiceBase.cs
@@ -1,10 +1,17 @@
-﻿namespace Pelican.Application.Abstractions.Infrastructure;
+﻿using Pelican.Application.Abstractions.Data.Repositories;
+
+namespace Pelican.Application.Abstractions.Infrastructure;
 
 public abstract class ServiceBase<TSettings>
 {
 	protected readonly IClient<TSettings> _client;
+	protected readonly IUnitOfWork _unitOfWork;
 
 	protected ServiceBase(
-		IClient<TSettings> client)
-		=> _client = client ?? throw new ArgumentNullException(nameof(client));
+		IClient<TSettings> client,
+		IUnitOfWork unitOfWork)
+	{
+		_client = client ?? throw new ArgumentNullException(nameof(client));
+		_unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+	}
 }

--- a/src/Pelican.Application/Clients/HubSpotCommands/Update/UpdateClientHubSpotCommandHandler.cs
+++ b/src/Pelican.Application/Clients/HubSpotCommands/Update/UpdateClientHubSpotCommandHandler.cs
@@ -126,7 +126,6 @@ internal sealed class UpdateClientHubSpotCommandHandler : ICommandHandler<Update
 	{
 		Result<string> accessTokenResult = await _hubSpotAuthorizationService.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 			portalId,
-			_unitOfWork,
 			cancellationToken);
 
 		if (accessTokenResult.IsFailure)

--- a/src/Pelican.Application/Contacts/HubSpotCommands/Update/UpdateContactHubSpotCommandHandler.cs
+++ b/src/Pelican.Application/Contacts/HubSpotCommands/Update/UpdateContactHubSpotCommandHandler.cs
@@ -147,7 +147,6 @@ internal sealed class UpdateContactHubSpotCommandHandler : ICommandHandler<Updat
 		Result<string> accessTokenResult = await _hubSpotAuthorizationService
 			.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				supplierHubSpotId,
-				_unitOfWork,
 				cancellationToken);
 
 		if (accessTokenResult.IsFailure)

--- a/src/Pelican.Application/Deals/HubSpotCommands/Update/UpdateDealHubSpotCommandHandler.cs
+++ b/src/Pelican.Application/Deals/HubSpotCommands/Update/UpdateDealHubSpotCommandHandler.cs
@@ -141,7 +141,6 @@ internal sealed class UpdateDealHubSpotCommandHandler : ICommandHandler<UpdateDe
 		Result<string> accessTokenResult = await _hubSpotAuthorizationService
 			.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				supplierHubSpotId,
-				_unitOfWork,
 				cancellationToken);
 
 		if (accessTokenResult.IsFailure)

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAccountManagerService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAccountManagerService.cs
@@ -1,4 +1,5 @@
-﻿using Pelican.Application.Abstractions.HubSpot;
+﻿using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.Abstractions.HubSpot;
 using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
@@ -12,8 +13,9 @@ namespace Pelican.Infrastructure.HubSpot.Services;
 internal sealed class HubSpotAccountManagerService : ServiceBase<HubSpotSettings>, IHubSpotOwnersService
 {
 	public HubSpotAccountManagerService(
-		IClient<HubSpotSettings> hubSpotClient)
-		: base(hubSpotClient)
+		IClient<HubSpotSettings> hubSpotClient,
+		IUnitOfWork unitOfWork)
+		: base(hubSpotClient, unitOfWork)
 	{ }
 
 	public async Task<Result<AccountManager>> GetByUserIdAsync(

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAuthorizationService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAuthorizationService.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.HubSpot;
 using Pelican.Application.Abstractions.Infrastructure;
@@ -20,8 +19,9 @@ internal sealed class HubSpotAuthorizationService : ServiceBase<HubSpotSettings>
 	private readonly HubSpotSettings _hubSpotSettings;
 	public HubSpotAuthorizationService(
 		IClient<HubSpotSettings> hubSpotClient,
-		IOptions<HubSpotSettings> hubSpotSettings)
-		: base(hubSpotClient)
+		IOptions<HubSpotSettings> hubSpotSettings,
+		IUnitOfWork unitOfWork)
+		: base(hubSpotClient, unitOfWork)
 	{
 		_hubSpotSettings = hubSpotSettings.Value ?? throw new ArgumentNullException(nameof(hubSpotSettings));
 	}

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAuthorizationService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAuthorizationService.cs
@@ -58,10 +58,9 @@ internal sealed class HubSpotAuthorizationService : ServiceBase<HubSpotSettings>
 
 	public async Task<Result<string>> RefreshAccessTokenFromSupplierHubSpotIdAsync(
 		long supplierHubSpotId,
-		IUnitOfWork unitOfWork,
 		CancellationToken cancellationToken)
 	{
-		Supplier? supplier = await unitOfWork
+		Supplier? supplier = await _unitOfWork
 			.SupplierRepository
 			.FirstOrDefaultAsync(
 				supplier => supplier.SourceId == supplierHubSpotId && supplier.Source == Sources.HubSpot,

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotClientService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotClientService.cs
@@ -13,14 +13,11 @@ namespace Pelican.Infrastructure.HubSpot.Services;
 
 internal sealed class HubSpotClientService : ServiceBase<HubSpotSettings>, IHubSpotObjectService<Client>
 {
-	private readonly IUnitOfWork _unitOfWork;
 	public HubSpotClientService(
 		IClient<HubSpotSettings> hubSpotClient,
 		IUnitOfWork unitOfWork)
-		: base(hubSpotClient)
-	{
-		_unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
-	}
+		: base(hubSpotClient, unitOfWork)
+	{ }
 
 	public async Task<Result<Client>> GetByIdAsync(
 		string accessToken,

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotContactService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotContactService.cs
@@ -13,13 +13,12 @@ namespace Pelican.Infrastructure.HubSpot.Services;
 
 internal sealed class HubSpotContactService : ServiceBase<HubSpotSettings>, IHubSpotObjectService<Contact>
 {
-	private readonly IUnitOfWork _unitOfWork;
 
 	public HubSpotContactService(
 		IClient<HubSpotSettings> hubSpotClient,
 		IUnitOfWork unitOfWork)
-		: base(hubSpotClient)
-		=> _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+		: base(hubSpotClient, unitOfWork)
+	{ }
 
 
 	public async Task<Result<Contact>> GetByIdAsync(

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotDealService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotDealService.cs
@@ -13,13 +13,11 @@ namespace Pelican.Infrastructure.HubSpot.Services;
 
 internal sealed class HubSpotDealService : ServiceBase<HubSpotSettings>, IHubSpotObjectService<Deal>
 {
-	private readonly IUnitOfWork _unitOfWork;
-
 	public HubSpotDealService(
 		IClient<HubSpotSettings> hubSpotClient,
 		IUnitOfWork unitOfWork)
-		: base(hubSpotClient)
-		=> _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+		: base(hubSpotClient, unitOfWork)
+	{ }
 
 	public async Task<Result<Deal>> GetByIdAsync(
 		string accessToken,

--- a/src/Pelican.Infrastructure.Pipedrive/Services/PipedriveDealService.cs
+++ b/src/Pelican.Infrastructure.Pipedrive/Services/PipedriveDealService.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+﻿using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Application.Abstractions.Pipedrive;
 using Pelican.Domain.Entities;
@@ -13,8 +13,8 @@ namespace Pelican.Infrastructure.Pipedrive.Services;
 public sealed class PipedriveDealService : ServiceBase<PipedriveSettings>, IPipedriveObjectService<Deal>
 {
 
-	public PipedriveDealService(IClient<PipedriveSettings> client)
-		: base(client)
+	public PipedriveDealService(IClient<PipedriveSettings> client, IUnitOfWork unitOfWork)
+		: base(client, unitOfWork)
 	{ }
 
 	public async Task<Result<Deal>> GetByIdAsync(

--- a/test/Pelican.Application.Test/Clients/Commands/UpdateClient/UpdateClientHubSpotCommandHandlerUnitTest.cs
+++ b/test/Pelican.Application.Test/Clients/Commands/UpdateClient/UpdateClientHubSpotCommandHandlerUnitTest.cs
@@ -99,7 +99,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Failure<string>(Error.NullValue));
 
@@ -142,7 +141,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success("AccessToken"));
 
@@ -200,7 +198,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success("AccessToken"));
 
@@ -273,7 +270,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success("AccessToken"));
 
@@ -362,7 +358,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Failure<string>(Error.NullValue));
 
@@ -373,7 +368,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Verify(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				portalId,
-				_unitOfWorkMock.Object,
 				default),
 			Times.Once);
 
@@ -404,7 +398,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success("AccessToken"));
 
@@ -422,7 +415,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Verify(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				portalId,
-				_unitOfWorkMock.Object,
 				default),
 			Times.Once);
 
@@ -455,7 +447,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success("AccessToken"));
 
@@ -514,7 +505,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Failure<string>(Error.NullValue));
 
@@ -525,7 +515,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Verify(
 			c => c.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				portalId,
-				_unitOfWorkMock.Object,
 				default),
 			Times.Once);
 
@@ -562,7 +551,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -630,7 +618,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -684,7 +671,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Failure<string>(Error.NullValue));
 
@@ -695,7 +681,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Verify(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				portalId,
-				_unitOfWorkMock.Object,
 				default),
 			Times.Once);
 
@@ -726,7 +711,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success("AccessToken"));
 
@@ -744,7 +728,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Verify(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				portalId,
-				_unitOfWorkMock.Object,
 				default),
 			Times.Once);
 
@@ -781,7 +764,6 @@ public class UpdateClientCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success("AccessToken"));
 

--- a/test/Pelican.Application.Test/Contacts/Commands/UpdateContact/UpdateContactHubSpotCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Contacts/Commands/UpdateContact/UpdateContactHubSpotCommandHandlerTests.cs
@@ -1,6 +1,4 @@
 ﻿using System.Linq.Expressions;
-using System.Threading;
-using Microsoft.EntityFrameworkCore;
 using Moq;
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.HubSpot;
@@ -114,7 +112,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Failure<string>(Error.NullValue));
 
@@ -129,7 +126,7 @@ public class UpdateContactHubSpotCommandHandlerTests
 
 		_hubSpotAuthorizationServiceMock
 			.Verify(h => h
-				.RefreshAccessTokenFromSupplierHubSpotIdAsync(SUPPLIER_HUBSPOT_ID, _unitOfWorkMock.Object, default), Times.Once);
+				.RefreshAccessTokenFromSupplierHubSpotIdAsync(SUPPLIER_HUBSPOT_ID, default), Times.Once);
 
 		Assert.True(result.IsFailure);
 
@@ -153,7 +150,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				_unitOfWorkMock.Object,
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -199,7 +195,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				_unitOfWorkMock.Object,
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -250,7 +245,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				_unitOfWorkMock.Object,
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -288,7 +282,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				_unitOfWorkMock.Object,
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -337,7 +330,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				_unitOfWorkMock.Object,
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -395,7 +387,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				_unitOfWorkMock.Object,
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -463,7 +454,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				_unitOfWorkMock.Object,
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -512,7 +502,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				_unitOfWorkMock.Object,
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -559,7 +548,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Failure<string>(Error.NullValue));
 
@@ -570,7 +558,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Verify(
 			c => c.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				portalId,
-				_unitOfWorkMock.Object,
 				default),
 			Times.Once);
 
@@ -603,7 +590,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -674,7 +660,6 @@ public class UpdateContactHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 

--- a/test/Pelican.Application.Test/Deals/Commands/UpdateDeal/UpdateDealHubSpotCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Deals/Commands/UpdateDeal/UpdateDealHubSpotCommandHandlerTests.cs
@@ -3,7 +3,6 @@ using Moq;
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.HubSpot;
 using Pelican.Application.Deals.HubSpotCommands.Update;
-using Pelican.Domain;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Shared;
 using Xunit;
@@ -140,7 +139,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service
-				.RefreshAccessTokenFromSupplierHubSpotIdAsync(It.IsAny<long>(), _unitOfWorkMock.Object, default))
+				.RefreshAccessTokenFromSupplierHubSpotIdAsync(It.IsAny<long>(), default))
 			.ReturnsAsync(Result.Failure<string>(error));
 
 		// Act
@@ -148,7 +147,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 
 		// Assert
 		_hubSpotAuthorizationServiceMock.Verify(
-			service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(SUPPLIERHUBSPOTID, _unitOfWorkMock.Object, default),
+			service => service.RefreshAccessTokenFromSupplierHubSpotIdAsync(SUPPLIERHUBSPOTID, default),
 			Times.Once);
 
 		Assert.True(result.IsFailure);
@@ -168,7 +167,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service
-				.RefreshAccessTokenFromSupplierHubSpotIdAsync(It.IsAny<long>(), _unitOfWorkMock.Object, default))
+				.RefreshAccessTokenFromSupplierHubSpotIdAsync(It.IsAny<long>(), default))
 			.ReturnsAsync(Result.Success(TOKEN));
 
 		_hubSpotDealServiceMock
@@ -203,7 +202,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service
-				.RefreshAccessTokenFromSupplierHubSpotIdAsync(It.IsAny<long>(), _unitOfWorkMock.Object, default))
+				.RefreshAccessTokenFromSupplierHubSpotIdAsync(It.IsAny<long>(), default))
 			.ReturnsAsync(Result.Success(TOKEN));
 
 		_hubSpotDealServiceMock
@@ -264,7 +263,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service
-				.RefreshAccessTokenFromSupplierHubSpotIdAsync(It.IsAny<long>(), _unitOfWorkMock.Object, default))
+				.RefreshAccessTokenFromSupplierHubSpotIdAsync(It.IsAny<long>(), default))
 			.ReturnsAsync(Result.Success(TOKEN));
 
 		_hubSpotDealServiceMock
@@ -337,7 +336,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 
 		_hubSpotAuthorizationServiceMock
 			.Setup(service => service
-				.RefreshAccessTokenFromSupplierHubSpotIdAsync(It.IsAny<long>(), _unitOfWorkMock.Object, default))
+				.RefreshAccessTokenFromSupplierHubSpotIdAsync(It.IsAny<long>(), default))
 			.ReturnsAsync(Result.Success(TOKEN));
 
 		_hubSpotDealServiceMock
@@ -526,7 +525,6 @@ public class UpdateDealHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Failure<string>(Error.NullValue));
 
@@ -537,7 +535,6 @@ public class UpdateDealHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Verify(
 			c => c.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				portalId,
-				_unitOfWorkMock.Object,
 				default),
 			Times.Once);
 
@@ -574,7 +571,6 @@ public class UpdateDealHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -644,7 +640,6 @@ public class UpdateDealHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 
@@ -729,7 +724,6 @@ public class UpdateDealHubSpotCommandHandlerTests
 		_hubSpotAuthorizationServiceMock.Setup(
 			h => h.RefreshAccessTokenFromSupplierHubSpotIdAsync(
 				It.IsAny<long>(),
-				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(accessToken));
 

--- a/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotAccountManagerServicesTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotAccountManagerServicesTests.cs
@@ -1,4 +1,5 @@
 ﻿using Moq;
+using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
@@ -13,23 +14,37 @@ namespace Pelican.Infrastructure.HubSpot.Test.Services;
 public class HubSpotAccountManagerServicesTests
 {
 	private readonly Mock<IClient<HubSpotSettings>> _hubSpotClientMock = new();
+	private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
 	private readonly HubSpotAccountManagerService _uut;
 
 	public HubSpotAccountManagerServicesTests()
 	{
-		_uut = new HubSpotAccountManagerService(_hubSpotClientMock.Object);
+		_uut = new HubSpotAccountManagerService(_hubSpotClientMock.Object, _unitOfWorkMock.Object);
 	}
 
 	[Fact]
 	public void HubSpotAccountManagerService_ClientNull_ThrowException()
 	{
 		// Act
-		var result = Record.Exception(() => new HubSpotAccountManagerService(null!));
+		var result = Record.Exception(() => new HubSpotAccountManagerService(null!, _unitOfWorkMock.Object));
 
 		// Assert
 		Assert.IsType<ArgumentNullException>(result);
 		Assert.Contains(
 			"client",
+			result.Message);
+	}
+
+	[Fact]
+	public void HubSpotAccountManagerService_UnitOfWorkNull_ThrowException()
+	{
+		// Act
+		var result = Record.Exception(() => new HubSpotAccountManagerService(_hubSpotClientMock.Object, null!));
+
+		// Assert
+		Assert.IsType<ArgumentNullException>(result);
+		Assert.Contains(
+			"unitOfWork",
 			result.Message);
 	}
 

--- a/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotAuthorizationServicesTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotAuthorizationServicesTests.cs
@@ -199,7 +199,7 @@ public class HubSpotAuthorizationServicesTests
 			.Returns(Enumerable.Empty<Supplier>().AsQueryable());
 
 		// Act
-		var result = await _uut.RefreshAccessTokenFromSupplierHubSpotIdAsync(1, _unitOfWorkMock.Object, default);
+		var result = await _uut.RefreshAccessTokenFromSupplierHubSpotIdAsync(1, default);
 
 		// Assert
 		Assert.True(result.IsFailure);
@@ -219,7 +219,7 @@ public class HubSpotAuthorizationServicesTests
 			.Returns(new List<Supplier> { supplier }.AsQueryable());
 
 		// Act
-		var result = await _uut.RefreshAccessTokenFromSupplierHubSpotIdAsync(1, _unitOfWorkMock.Object, default);
+		var result = await _uut.RefreshAccessTokenFromSupplierHubSpotIdAsync(1, default);
 
 		// Assert
 		Assert.True(result.IsFailure);
@@ -251,7 +251,7 @@ public class HubSpotAuthorizationServicesTests
 			.ReturnsAsync(responseMock.Object);
 
 		// Act
-		var result = await _uut.RefreshAccessTokenFromSupplierHubSpotIdAsync(0, _unitOfWorkMock.Object, default);
+		var result = await _uut.RefreshAccessTokenFromSupplierHubSpotIdAsync(0, default);
 
 		// Assert
 		Assert.True(result.IsFailure);
@@ -283,7 +283,7 @@ public class HubSpotAuthorizationServicesTests
 			.ReturnsAsync(responseMock.Object);
 
 		// Act
-		var result = await _uut.RefreshAccessTokenFromSupplierHubSpotIdAsync(0, _unitOfWorkMock.Object, default);
+		var result = await _uut.RefreshAccessTokenFromSupplierHubSpotIdAsync(0, default);
 
 		// Assert
 		Assert.True(result.IsSuccess);

--- a/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotAuthorizationServicesTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotAuthorizationServicesTests.cs
@@ -47,19 +47,32 @@ public class HubSpotAuthorizationServicesTests
 
 		_uut = new(
 			_hubSpotClientMock.Object,
-			_optionsMock.Object);
+			_optionsMock.Object, _unitOfWorkMock.Object);
 	}
 
 	[Fact]
 	public void HubSpotAuthorizationService_ClientNull_ThrowException()
 	{
 		// Act
-		var result = Record.Exception(() => new HubSpotAuthorizationService(null!, null!));
+		var result = Record.Exception(() => new HubSpotAuthorizationService(null!, null!, _unitOfWorkMock.Object));
 
 		// Assert
 		Assert.IsType<ArgumentNullException>(result);
 		Assert.Contains(
 			"client",
+			result.Message);
+	}
+
+	[Fact]
+	public void HubSpotAuthorizationService_UnitOfWorkNull_ThrowException()
+	{
+		// Act
+		var result = Record.Exception(() => new HubSpotAuthorizationService(_hubSpotClientMock.Object, null!, null!));
+
+		// Assert
+		Assert.IsType<ArgumentNullException>(result);
+		Assert.Contains(
+			"unitOfWork",
 			result.Message);
 	}
 
@@ -72,7 +85,7 @@ public class HubSpotAuthorizationServicesTests
 			.Returns((HubSpotSettings)null!);
 
 		// Act
-		var result = Record.Exception(() => new HubSpotAuthorizationService(_hubSpotClientMock.Object, _optionsMock.Object));
+		var result = Record.Exception(() => new HubSpotAuthorizationService(_hubSpotClientMock.Object, _optionsMock.Object, _unitOfWorkMock.Object));
 
 		// Assert
 		Assert.IsType<ArgumentNullException>(result);

--- a/test/Pelican.Infrastructure.Pipedrive.Test/Services/PipedriveDealServiceTests.cs
+++ b/test/Pelican.Infrastructure.Pipedrive.Test/Services/PipedriveDealServiceTests.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.Extensions.Options;
-using Moq;
+﻿using Moq;
+using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.Infrastructure;
-using Pelican.Application.RestSharp;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.Pipedrive;
 using Pelican.Domain.Shared;
@@ -15,18 +14,19 @@ namespace Pelican.Infrastructure.Pipedrive.Test.Services;
 public class PipedriveDealServiceTests
 {
 	private readonly Mock<IClient<PipedriveSettings>> _clientMock = new();
+	private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
 	private readonly PipedriveDealService _uut;
 
 	public PipedriveDealServiceTests()
 	{
-		_uut = new(_clientMock.Object);
+		_uut = new(_clientMock.Object, _unitOfWorkMock.Object);
 	}
 
 	[Fact]
-	public void PipedriveDealService_ArgumentNull_ThrowException()
+	public void PipedriveDealService_ClientArgumentNull_ThrowException()
 	{
 		// Act
-		var result = Record.Exception(() => new PipedriveDealService(null!));
+		var result = Record.Exception(() => new PipedriveDealService(null!, _unitOfWorkMock.Object));
 
 		// Assert
 		Assert.IsType<ArgumentNullException>(result);
@@ -36,6 +36,19 @@ public class PipedriveDealServiceTests
 			result.Message);
 	}
 
+	[Fact]
+	public void PipedriveDealService_UnitOfWorkArgumentNull_ThrowException()
+	{
+		// Act
+		var result = Record.Exception(() => new PipedriveDealService(_clientMock.Object, null!));
+
+		// Assert
+		Assert.IsType<ArgumentNullException>(result);
+
+		Assert.Contains(
+			"unitOfWork",
+			result.Message);
+	}
 
 	[Fact]
 	public async Task GetByIdAsync_ClientReturnsFailureResult_ReturnFailure()


### PR DESCRIPTION
Moved IUnitOfWork to service base, this was done since unitOfWork is used for most services and can be reused again in the future pipedriveServices.