### PR TITLE
Feature/plcn 299 remove entity constructors with guid

### DIFF
--- a/src/Pelican.Application/HubSpot/Commands/NewInstallation/NewInstallationHubSpotCommandHandler.cs
+++ b/src/Pelican.Application/HubSpot/Commands/NewInstallation/NewInstallationHubSpotCommandHandler.cs
@@ -100,7 +100,7 @@ internal sealed class NewInstallationHubSpotCommandHandler : ICommandHandler<New
 
 				accountManager.AccountManagerDeals = deals
 					.Where(deal => deal.SourceOwnerId == accountManager.SourceId && deal.Source == Sources.HubSpot)?
-					.Select(deal => new AccountManagerDeal(Guid.NewGuid())
+					.Select(deal => new AccountManagerDeal()
 					{
 						AccountManager = accountManager,
 						AccountManagerId = accountManager.Id,

--- a/src/Pelican.Application/PelicanBogusFaker.cs
+++ b/src/Pelican.Application/PelicanBogusFaker.cs
@@ -22,7 +22,6 @@ public class PelicanBogusFaker : IPelicanBogusFaker
 			.RuleFor(e => e.Supplier, f => f.PickRandom<Supplier>(suppliers))
 			.RuleFor(e => e.SourceId, f => f.Random.Guid().ToString())
 			.RuleFor(e => e.SourceUserId, f => f.Random.Long(1))
-			.RuleFor(e => e.Id, f => f.Random.Guid())
 			.RuleFor(e => e.Source, () => new Random().Next(2) <= 1 ? Sources.HubSpot : Sources.Pipedrive);
 		return faker.Generate(count);
 	}
@@ -39,7 +38,6 @@ public class PelicanBogusFaker : IPelicanBogusFaker
 			.RuleFor(e => e.WebsiteUrl, f => f.Internet.Url().OrNull(f, 0.0f))
 			.RuleFor(e => e.SourceId, f => f.Random.Long(1))
 			.RuleFor(e => e.RefreshToken, f => f.Random.Guid().ToString())
-			.RuleFor(e => e.Id, f => f.Random.Guid())
 			.RuleFor(e => e.PipedriveDomain, f => f.Internet.Url().OrNull(f, 0.0f))
 			.RuleFor(e => e.OfficeLocation, f => f.Address.City().OrNull(f, 0.0f))
 			.RuleFor(e => e.Source, () => new Random().Next(2) == 1 ? Sources.HubSpot : Sources.Pipedrive);
@@ -55,7 +53,6 @@ public class PelicanBogusFaker : IPelicanBogusFaker
 			.RuleFor(e => e.Status, f => f.PickRandom<DealStatus>().ToString().OrNull(f, 0.0f))
 			.RuleFor(e => e.EndDate, f => f.Date.Future().Ticks.OrNull(f, 0.0f))
 			.RuleFor(e => e.StartDate, f => f.Date.Future().Ticks.OrNull(f, 0.0f))
-			.RuleFor(e => e.Id, f => f.Random.Guid())
 			.RuleFor(e => e.LastContactDate, f => f.Date.Future().Ticks.OrNull(f, 0.0f))
 			.RuleFor(e => e.ClientId, f => f.PickRandom<Client>(clients).Id)
 			.RuleFor(e => e.Client, f => f.PickRandom<Client>(clients))
@@ -74,8 +71,7 @@ public class PelicanBogusFaker : IPelicanBogusFaker
 			.RuleFor(e => e.OfficeLocation, f => f.Address.City().OrNull(f, 0.0f))
 			.RuleFor(e => e.SourceId, f => f.Random.Guid().ToString())
 			.RuleFor(e => e.Website, f => f.Internet.Url().OrNull(f, 0.0f))
-			.RuleFor(e => e.Source, () => new Random().Next(2) == 1 ? Sources.HubSpot : Sources.Pipedrive)
-			.RuleFor(e => e.Id, f => f.Random.Guid());
+			.RuleFor(e => e.Source, () => new Random().Next(2) == 1 ? Sources.HubSpot : Sources.Pipedrive);
 		return faker.Generate(count);
 	}
 
@@ -90,7 +86,6 @@ public class PelicanBogusFaker : IPelicanBogusFaker
 			.RuleFor(e => e.JobTitle, f => f.Name.JobTitle().OrNull(f, 0.0f))
 			.RuleFor(e => e.SourceId, f => f.Random.Guid().ToString())
 			.RuleFor(e => e.SourceOwnerId, f => f.PickRandom<AccountManager>(accountManagers).SourceId.OrNull(f, 0.0f))
-			.RuleFor(e => e.Id, f => f.Random.Guid())
 			.RuleFor(e => e.Source, () => new Random().Next(2) == 1 ? Sources.HubSpot : Sources.Pipedrive);
 		return faker.Generate(count);
 	}
@@ -101,7 +96,6 @@ public class PelicanBogusFaker : IPelicanBogusFaker
 			.RuleFor(e => e.DealId, f => f.PickRandom<Deal>(deals).Id)
 			.RuleFor(e => e.AccountManagerId, f => f.PickRandom<AccountManager>(accountManagers).Id)
 			.RuleFor(e => e.IsActive, () => new Random().Next(100) <= 50)
-			.RuleFor(e => e.Id, f => f.Random.Guid())
 			.RuleFor(e => e.SourceAccountManagerId, f => f.PickRandom<AccountManager>(accountManagers).SourceId)
 			.RuleFor(e => e.SourceDealId, f => f.PickRandom<Deal>(deals).SourceId)
 			.Generate(accountManagers.Count());
@@ -112,7 +106,6 @@ public class PelicanBogusFaker : IPelicanBogusFaker
 			.RuleFor(e => e.DealId, f => f.PickRandom<Deal>(deals).Id)
 			.RuleFor(e => e.ContactId, f => f.PickRandom<Contact>(contacts).Id)
 			.RuleFor(e => e.IsActive, () => new Random().Next(100) <= 50)
-			.RuleFor(e => e.Id, f => f.Random.Guid())
 			.RuleFor(e => e.SourceContactId, f => f.PickRandom<Contact>(contacts).SourceId)
 			.RuleFor(e => e.SourceDealId, f => f.PickRandom<Deal>(deals).SourceId)
 			.Generate(deals.Count());
@@ -123,7 +116,6 @@ public class PelicanBogusFaker : IPelicanBogusFaker
 			.RuleFor(e => e.ClientId, f => f.PickRandom<Client>(clients).Id)
 			.RuleFor(e => e.ContactId, f => f.PickRandom<Contact>(contacts).Id)
 			.RuleFor(e => e.IsActive, () => new Random().Next(100) <= 50)
-			.RuleFor(e => e.Id, f => f.Random.Guid())
 			.RuleFor(e => e.SourceClientId, f => f.PickRandom<Client>(clients).SourceId)
 			.RuleFor(e => e.SourceContactId, f => f.PickRandom<Contact>(contacts).SourceId)
 			.Generate(clients.Count());

--- a/src/Pelican.Domain/Entities/AccountManager.cs
+++ b/src/Pelican.Domain/Entities/AccountManager.cs
@@ -9,8 +9,6 @@ public class AccountManager : Entity, ITimeTracked
 	private string? _phoneNumber;
 	private string? _linkedInUrl;
 
-	public AccountManager(Guid id) : base(id) { }
-
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 	public AccountManager() { }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/src/Pelican.Domain/Entities/AccountManagerDeal.cs
+++ b/src/Pelican.Domain/Entities/AccountManagerDeal.cs
@@ -5,7 +5,9 @@ using Pelican.Domain.Primitives;
 
 public class AccountManagerDeal : Entity, ITimeTracked
 {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 	public AccountManagerDeal() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
 	public bool IsActive { get; set; }
 

--- a/src/Pelican.Domain/Entities/AccountManagerDeal.cs
+++ b/src/Pelican.Domain/Entities/AccountManagerDeal.cs
@@ -5,8 +5,6 @@ using Pelican.Domain.Primitives;
 
 public class AccountManagerDeal : Entity, ITimeTracked
 {
-	public AccountManagerDeal(Guid id) : base(id) { }
-
 	public AccountManagerDeal() { }
 
 	public bool IsActive { get; set; }

--- a/src/Pelican.Domain/Entities/Client.cs
+++ b/src/Pelican.Domain/Entities/Client.cs
@@ -6,9 +6,6 @@ public class Client : Entity, ITimeTracked
 {
 	private string _name = string.Empty;
 	private string? _website { get; set; }
-
-	public Client(Guid id) : base(id) { }
-
 	public Client() { }
 
 	public string Source { get; set; } = string.Empty;

--- a/src/Pelican.Domain/Entities/ClientContact.cs
+++ b/src/Pelican.Domain/Entities/ClientContact.cs
@@ -4,8 +4,6 @@ using Pelican.Domain.Primitives;
 namespace Pelican.Domain.Entities;
 public class ClientContact : Entity, ITimeTracked
 {
-	public ClientContact(Guid id) : base(id) { }
-
 	public ClientContact() { }
 
 

--- a/src/Pelican.Domain/Entities/ClientContact.cs
+++ b/src/Pelican.Domain/Entities/ClientContact.cs
@@ -4,7 +4,9 @@ using Pelican.Domain.Primitives;
 namespace Pelican.Domain.Entities;
 public class ClientContact : Entity, ITimeTracked
 {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 	public ClientContact() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
 	public bool IsActive { get; set; }
 

--- a/src/Pelican.Domain/Entities/ClientContact.cs
+++ b/src/Pelican.Domain/Entities/ClientContact.cs
@@ -6,7 +6,6 @@ public class ClientContact : Entity, ITimeTracked
 {
 	public ClientContact() { }
 
-
 	public bool IsActive { get; set; }
 
 

--- a/src/Pelican.Domain/Entities/Contact.cs
+++ b/src/Pelican.Domain/Entities/Contact.cs
@@ -11,7 +11,6 @@ public class Contact : Entity, ITimeTracked
 	private string? _jobTitle;
 	private string? _email;
 
-	public Contact(Guid id) : base(id) { }
 	public Contact() { }
 
 	public string Source { get; set; } = string.Empty;

--- a/src/Pelican.Domain/Entities/Deal.cs
+++ b/src/Pelican.Domain/Entities/Deal.cs
@@ -10,8 +10,6 @@ public class Deal : Entity, ITimeTracked
 	private string? _status;
 	private string? _description;
 
-	public Deal(Guid id) : base(id) { }
-
 	public Deal() { }
 
 	public string Source { get; set; } = string.Empty;

--- a/src/Pelican.Domain/Entities/DealContact.cs
+++ b/src/Pelican.Domain/Entities/DealContact.cs
@@ -5,7 +5,9 @@ namespace Pelican.Domain.Entities;
 
 public class DealContact : Entity, ITimeTracked
 {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 	public DealContact() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
 	public bool IsActive { get; set; }
 

--- a/src/Pelican.Domain/Entities/DealContact.cs
+++ b/src/Pelican.Domain/Entities/DealContact.cs
@@ -5,8 +5,6 @@ namespace Pelican.Domain.Entities;
 
 public class DealContact : Entity, ITimeTracked
 {
-	public DealContact(Guid id) : base(id) { }
-
 	public DealContact() { }
 
 	public bool IsActive { get; set; }

--- a/src/Pelican.Domain/Entities/Supplier.cs
+++ b/src/Pelican.Domain/Entities/Supplier.cs
@@ -11,8 +11,6 @@ public class Supplier : Entity, ITimeTracked
 	private string? _websiteUrl;
 	private string? _officeLocation;
 
-	public Supplier(Guid id) : base(id) { }
-
 	public Supplier() { }
 
 	public string Source { get; set; } = string.Empty;

--- a/src/Pelican.Domain/Primitives/Entity.cs
+++ b/src/Pelican.Domain/Primitives/Entity.cs
@@ -1,8 +1,6 @@
 ﻿namespace Pelican.Domain.Primitives;
 public abstract class Entity : IEquatable<Entity>
 {
-	protected Entity(Guid id) => Id = id;
-
 	protected Entity() { }
 
 	public Guid Id { get; set; }

--- a/src/Pelican.Infrastructure.HubSpot/Mapping/AccountManagers/OwnerResponseToAccountManager.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Mapping/AccountManagers/OwnerResponseToAccountManager.cs
@@ -16,7 +16,7 @@ internal static class OwnerResponseToAccountManager
 		{
 			throw new ArgumentNullException(nameof(response));
 		}
-		AccountManager result = new(Guid.NewGuid())
+		AccountManager result = new()
 		{
 			SourceId = response.Id,
 			SourceUserId = response.UserId,

--- a/src/Pelican.Infrastructure.HubSpot/Mapping/Auth/AccessTokenResponseToSupplier.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Mapping/Auth/AccessTokenResponseToSupplier.cs
@@ -7,7 +7,7 @@ namespace Pelican.Infrastructure.HubSpot.Mapping.Auth;
 internal static class AccessTokenResponseToSupplier
 {
 	internal static Supplier ToSupplier(this AccessTokenResponse response)
-		=> new(Guid.NewGuid())
+		=> new()
 		{
 			WebsiteUrl = response.HubDomain,
 			SourceId = response.HubId,

--- a/test/Pelican.Application.Test/AccountManagers/Commands/ValidateWebhookUserId/ValidateWebhookUserIdCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/AccountManagers/Commands/ValidateWebhookUserId/ValidateWebhookUserIdCommandHandlerTests.cs
@@ -85,7 +85,7 @@ public class ValidateWebhookUserIdCommandHandlerTests
 			.Setup(u => u.AccountManagerRepository.FirstOrDefaultAsync(
 				It.IsAny<Expression<Func<AccountManager, bool>>>(),
 				It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new AccountManager(Guid.NewGuid()));
+			.ReturnsAsync(new AccountManager());
 
 		// Act 
 		var result = await _uut.Handle(command, default);
@@ -147,7 +147,7 @@ public class ValidateWebhookUserIdCommandHandlerTests
 			.Setup(u => u.SupplierRepository.FirstOrDefaultAsync(
 				It.IsAny<Expression<Func<Supplier, bool>>>(),
 				It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new Supplier(Guid.NewGuid())
+			.ReturnsAsync(new Supplier()
 			{
 				RefreshToken = REFRESH_TOKEN,
 			});
@@ -187,7 +187,7 @@ public class ValidateWebhookUserIdCommandHandlerTests
 			.Setup(u => u.SupplierRepository.FirstOrDefaultAsync(
 				It.IsAny<Expression<Func<Supplier, bool>>>(),
 				It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new Supplier(Guid.NewGuid())
+			.ReturnsAsync(new Supplier()
 			{
 				RefreshToken = REFRESH_TOKEN,
 			});
@@ -225,7 +225,7 @@ public class ValidateWebhookUserIdCommandHandlerTests
 		// Arrange
 		ValidateWebhookUserIdCommand command = new(1, 1);
 
-		AccountManager accountManager = new(Guid.NewGuid());
+		AccountManager accountManager = new();
 
 		_unitOfWorkMock
 			.Setup(u => u.AccountManagerRepository.FirstOrDefaultAsync(
@@ -237,7 +237,7 @@ public class ValidateWebhookUserIdCommandHandlerTests
 			.Setup(u => u.SupplierRepository.FirstOrDefaultAsync(
 				It.IsAny<Expression<Func<Supplier, bool>>>(),
 				It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new Supplier(Guid.NewGuid())
+			.ReturnsAsync(new Supplier()
 			{
 				RefreshToken = REFRESH_TOKEN,
 			});

--- a/test/Pelican.Application.Test/AccountManagers/Queries/GetAccountManagerByIdQueryHandlerUnitTest.cs
+++ b/test/Pelican.Application.Test/AccountManagers/Queries/GetAccountManagerByIdQueryHandlerUnitTest.cs
@@ -17,7 +17,7 @@ public class GetAccountManagerByIdQueryHandlerUnitTest
 		var guid = Guid.NewGuid();
 		GetAccountManagerByIdQuery getAccountManagerByIdQuery = new GetAccountManagerByIdQuery(guid);
 		List<AccountManager> resultList = new List<AccountManager>();
-		dataLoaderMock.Setup(x => x.LoadAsync(guid, cancellationToken)).ReturnsAsync(new AccountManager(guid));
+		dataLoaderMock.Setup(x => x.LoadAsync(guid, cancellationToken)).ReturnsAsync(new AccountManager() { Id = guid });
 		//Act
 		resultList.Add(await uut.Handle(getAccountManagerByIdQuery, cancellationToken));
 		//Assert

--- a/test/Pelican.Application.Test/Behaviours/ValidationBehaviourTests.cs
+++ b/test/Pelican.Application.Test/Behaviours/ValidationBehaviourTests.cs
@@ -24,7 +24,7 @@ public class ValidationBehaviourTests
 		Mock<RequestHandlerDelegate<Deal>> delegateMock = new();
 
 
-		Deal deal = new Deal(Guid.NewGuid());
+		Deal deal = new Deal();
 
 		delegateMock
 			.Setup(d => d())
@@ -69,7 +69,7 @@ public class ValidationBehaviourTests
 
 		Mock<RequestHandlerDelegate<Result<Deal>>> delegateMock = new();
 
-		Result<Deal> dealResult = new Deal(Guid.NewGuid());
+		Result<Deal> dealResult = new Deal();
 
 		delegateMock
 			.Setup(d => d())
@@ -110,7 +110,7 @@ public class ValidationBehaviourTests
 
 		Mock<RequestHandlerDelegate<Result<Deal>>> delegateMock = new();
 
-		Result<Deal> dealResult = new Deal(Guid.NewGuid());
+		Result<Deal> dealResult = new Deal();
 
 		delegateMock
 			.Setup(d => d())

--- a/test/Pelican.Application.Test/Clients/Commands/DeleteClient/DeleteClientHubSpotCommandHandlerUnitTest.cs
+++ b/test/Pelican.Application.Test/Clients/Commands/DeleteClient/DeleteClientHubSpotCommandHandlerUnitTest.cs
@@ -71,7 +71,7 @@ public class DeleteClientHubSpotCommandHandlerUnitTest
 	{
 		//Arrange
 		DeleteClientHubSpotCommand deleteClientCommand = new(1);
-		Client client = new(Guid.NewGuid());
+		Client client = new();
 		_fakeUnitOfWork.Setup(x => x
 			.ClientRepository
 			.FindByCondition(It.IsAny<Expression<Func<Client, bool>>>()))

--- a/test/Pelican.Application.Test/Clients/Commands/UpdateClient/UpdateClientHubSpotCommandHandlerUnitTest.cs
+++ b/test/Pelican.Application.Test/Clients/Commands/UpdateClient/UpdateClientHubSpotCommandHandlerUnitTest.cs
@@ -129,7 +129,7 @@ public class UpdateClientCommandHandlerTests
 		// Arrange
 		UpdateClientHubSpotCommand command = new(objectId, portalId, updateTime, propertyName, propertyValue);
 
-		Supplier supplier = new(Guid.NewGuid())
+		Supplier supplier = new()
 		{
 			RefreshToken = "token",
 		};
@@ -181,7 +181,7 @@ public class UpdateClientCommandHandlerTests
 		// Arrange
 		UpdateClientHubSpotCommand command = new(objectId, portalId, updateTime, propertyName, propertyValue);
 
-		Supplier supplier = new(Guid.NewGuid())
+		Supplier supplier = new()
 		{
 			RefreshToken = "token",
 		};
@@ -241,14 +241,14 @@ public class UpdateClientCommandHandlerTests
 		// Arrange
 		UpdateClientHubSpotCommand command = new(objectId, portalId, updateTime, propertyName, propertyValue);
 
-		Supplier supplier = new(Guid.NewGuid())
+		Supplier supplier = new()
 		{
 			RefreshToken = "token",
 		};
 		Mock<Client> clientMock = new();
 		ClientContact clientContact = new();
 		List<ClientContact> clientContactList = new();
-		Contact contact = new(Guid.NewGuid())
+		Contact contact = new()
 		{
 			SourceId = "HubSpotId"
 		};
@@ -464,7 +464,7 @@ public class UpdateClientCommandHandlerTests
 				It.IsAny<string>(),
 				It.IsAny<long>(),
 				It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new Client(Guid.NewGuid()));
+			.ReturnsAsync(new Client());
 
 		_unitOfWorkMock
 			.Setup(u => u
@@ -616,7 +616,7 @@ public class UpdateClientCommandHandlerTests
 			Website = testWebsite,
 			ClientContacts = new List<ClientContact>()
 			{
-				new ClientContact(Guid.NewGuid())
+				new ClientContact()
 			},
 		};
 
@@ -790,7 +790,7 @@ public class UpdateClientCommandHandlerTests
 				It.IsAny<string>(),
 				It.IsAny<long>(),
 				It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new Client(Guid.NewGuid())
+			.ReturnsAsync(new Client()
 			{
 				Deals = dealList,
 			});

--- a/test/Pelican.Application.Test/Clients/Queries/GetClientByIdQueryHandlerUnitTest.cs
+++ b/test/Pelican.Application.Test/Clients/Queries/GetClientByIdQueryHandlerUnitTest.cs
@@ -16,7 +16,7 @@ public class GetClientByIdQueryHandlerUnitTest
 		var guid = Guid.NewGuid();
 		GetClientByIdQuery getClientByIdQuery = new GetClientByIdQuery(guid);
 		List<Client> resultList = new List<Client>();
-		dataLoaderMock.Setup(x => x.LoadAsync(guid, cancellationToken)).ReturnsAsync(new Client(guid));
+		dataLoaderMock.Setup(x => x.LoadAsync(guid, cancellationToken)).ReturnsAsync(new Client() { Id = guid });
 		//Act
 		resultList.Add(await uut.Handle(getClientByIdQuery, cancellationToken));
 		//Assert

--- a/test/Pelican.Application.Test/Contacts/Commands/UpdateContact/UpdateContactHubSpotCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Contacts/Commands/UpdateContact/UpdateContactHubSpotCommandHandlerTests.cs
@@ -663,7 +663,7 @@ public class UpdateContactHubSpotCommandHandlerTests
 			SourceOwnerId = testSourceOwnerId,
 			DealContacts = new List<DealContact>()
 			{
-				new DealContact(Guid.NewGuid())
+				new DealContact()
 			},
 		};
 

--- a/test/Pelican.Application.Test/Contacts/Queries/GetContactByIdQueryHandlerUnitTest.cs
+++ b/test/Pelican.Application.Test/Contacts/Queries/GetContactByIdQueryHandlerUnitTest.cs
@@ -17,7 +17,7 @@ public class GetContactByIdQueryHandlerUnitTest
 		var guid = Guid.NewGuid();
 		GetContactByIdQuery getContactByIdQuery = new GetContactByIdQuery(guid);
 		List<Contact> resultList = new List<Contact>();
-		dataLoaderMock.Setup(x => x.LoadAsync(guid, cancellationToken)).ReturnsAsync(new Contact(guid));
+		dataLoaderMock.Setup(x => x.LoadAsync(guid, cancellationToken)).ReturnsAsync(new Contact() { Id = guid });
 		//Act
 		resultList.Add(await uut.Handle(getContactByIdQuery, cancellationToken));
 		//Assert

--- a/test/Pelican.Application.Test/Deals/Commands/DeleteDeal/DeleteDealHubSpotCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Deals/Commands/DeleteDeal/DeleteDealHubSpotCommandHandlerTests.cs
@@ -86,7 +86,7 @@ public class DeleteDealHubSpotCommandHandlerTests
 	{
 		// Arrange
 		DeleteDealHubSpotCommand command = new(0);
-		Deal deal = new(Guid.NewGuid());
+		Deal deal = new();
 
 		_unitOfWorkMock
 			.Setup(unitOfWork => unitOfWork

--- a/test/Pelican.Application.Test/Deals/Commands/UpdateDeal/UpdateDealHubSpotCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Deals/Commands/UpdateDeal/UpdateDealHubSpotCommandHandlerTests.cs
@@ -235,12 +235,12 @@ public class UpdateDealHubSpotCommandHandlerTests
 		// Arrange
 		UpdateDealHubSpotCommand command = new(OBJECTID, SUPPLIERHUBSPOTID, UPDATETIME, EMPTY_PROPERTYNAME, EMPTY_PROPERTYVALUE);
 
-		Contact existingContact = new(Guid.NewGuid())
+		Contact existingContact = new()
 		{
 			SourceId = "contactHubSpotId",
 		};
 
-		Client existingClient = new(Guid.NewGuid())
+		Client existingClient = new()
 		{
 			SourceId = "clientHubSpotId",
 		};
@@ -253,7 +253,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 		newDealMock.Object.Client = existingClient;
 		newDealMock.Object.DealContacts = new List<DealContact>()
 		{
-			new DealContact(Guid.NewGuid())
+			new DealContact()
 			{
 				Deal = newDealMock.Object,
 				DealId = newDealMock.Object.Id,
@@ -308,12 +308,12 @@ public class UpdateDealHubSpotCommandHandlerTests
 
 		Deal? existingDeal = null;
 
-		Contact existingContact = new(Guid.NewGuid())
+		Contact existingContact = new()
 		{
 			SourceId = "contactHubSpotId",
 		};
 
-		Client existingClient = new(Guid.NewGuid())
+		Client existingClient = new()
 		{
 			SourceId = "clientHubSpotId",
 		};
@@ -326,7 +326,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 		newDealMock.Object.Client = existingClient;
 		newDealMock.Object.DealContacts = new List<DealContact>()
 		{
-			new DealContact(Guid.NewGuid())
+			new DealContact()
 			{
 				Deal = newDealMock.Object,
 				DealId = newDealMock.Object.Id,
@@ -377,7 +377,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 	public async void Handle_DealFoundAccountManagerAssociationUpdatedIdEqualToActive_ReturnsSuccess()
 	{
 		// Arrange
-		Mock<Deal> dealMock = new(Guid.NewGuid());
+		Mock<Deal> dealMock = new();
 		dealMock.Object.AccountManagerDeals = new List<AccountManagerDeal>()
 		{
 			new AccountManagerDeal()
@@ -408,7 +408,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 	public async void Handle_DealFoundAccountManagerAssociationUpdated_ReturnsSuccess()
 	{
 		// Arrange
-		Mock<Deal> dealMock = new(Guid.NewGuid());
+		Mock<Deal> dealMock = new();
 
 		SetupDealRepositoryMock(dealMock.Object);
 
@@ -419,7 +419,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 				.FirstOrDefaultAsync(
 					It.IsAny<Expression<Func<AccountManager, bool>>>(),
 					default))
-			.ReturnsAsync(new AccountManager(Guid.NewGuid()));
+			.ReturnsAsync(new AccountManager());
 
 		_accountManagerDealRepositoryMock
 			.Setup(a => a.Attach(It.IsAny<AccountManagerDeal>()));
@@ -441,7 +441,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 	public async void Handle_DealFoundAccountManagerAssociationUpdatedAccountManagerNotFound_ReturnsSuccessWithoutChanges()
 	{
 		// Arrange
-		Mock<Deal> dealMock = new(Guid.NewGuid());
+		Mock<Deal> dealMock = new();
 
 		SetupDealRepositoryMock(dealMock.Object);
 
@@ -706,7 +706,7 @@ public class UpdateDealHubSpotCommandHandlerTests
 
 			AccountManagerDeals = new List<AccountManagerDeal>()
 			{
-				new AccountManagerDeal(Guid.NewGuid())
+				new AccountManagerDeal()
 			},
 		};
 		Mock<AccountManager> accountManagerMock = new();

--- a/test/Pelican.Application.Test/Deals/Queries/GetDealByIdQueryHandlerUnitTest.cs
+++ b/test/Pelican.Application.Test/Deals/Queries/GetDealByIdQueryHandlerUnitTest.cs
@@ -17,7 +17,7 @@ public class GetDealByIdQueryHandlerUnitTest
 		var guid = Guid.NewGuid();
 		GetDealByIdQuery getDealByIdQuery = new GetDealByIdQuery(guid);
 		List<Deal> resultList = new List<Deal>();
-		dataLoaderMock.Setup(x => x.LoadAsync(guid, cancellationToken)).ReturnsAsync(new Deal(guid));
+		dataLoaderMock.Setup(x => x.LoadAsync(guid, cancellationToken)).ReturnsAsync(new Deal() { Id = guid });
 		//Act
 		resultList.Add(await uut.Handle(getDealByIdQuery, cancellationToken));
 		//Assert

--- a/test/Pelican.Application.Test/HubSpot/Commands/NewInstallation/NewInstallationCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/HubSpot/Commands/NewInstallation/NewInstallationCommandHandlerTests.cs
@@ -130,7 +130,7 @@ public class NewInstallationCommandHandlerTests
 				h => h.DecodeAccessTokenAsync(token2, cancellationToken))
 			.ReturnsAsync(
 				Result.Success(
-					new Supplier(Guid.NewGuid())));
+					new Supplier()));
 
 		_hubSpotAccountManagerServiceMock
 			.Setup(

--- a/test/Pelican.Application.Test/Suppliers/Queries/GetSupplierByIdQueryHandlerUnitTest.cs
+++ b/test/Pelican.Application.Test/Suppliers/Queries/GetSupplierByIdQueryHandlerUnitTest.cs
@@ -16,7 +16,7 @@ public class GetSupplierByIdQueryHandlerUnitTest
 		var guid = Guid.NewGuid();
 		GetSupplierByIdQuery getSupplierByIdQuery = new GetSupplierByIdQuery(guid);
 		List<Supplier> resultList = new List<Supplier>();
-		dataLoaderMock.Setup(x => x.LoadAsync(guid, cancellationToken)).ReturnsAsync(new Supplier(guid));
+		dataLoaderMock.Setup(x => x.LoadAsync(guid, cancellationToken)).ReturnsAsync(new Supplier() { Id = guid });
 		//Act
 		resultList.Add(await uut.Handle(getSupplierByIdQuery, cancellationToken));
 		//Assert

--- a/test/Pelican.Domain.Test/Entities/AccountManagerDealTests.cs
+++ b/test/Pelican.Domain.Test/Entities/AccountManagerDealTests.cs
@@ -12,13 +12,13 @@ public class AccountManagerDealTests
 		const string DEAL_HUBSPOTID = "dealhubspotid";
 		const string ACCOUNTMANAGER_HUBSPOTID = "accountmanagerhubspotid";
 
-		Deal deal = new(Guid.NewGuid())
+		Deal deal = new()
 		{
 			SourceId = DEAL_HUBSPOTID,
 			Source = Sources.HubSpot,
 		};
 
-		AccountManager accountManager = new(Guid.NewGuid())
+		AccountManager accountManager = new()
 		{
 			SourceId = ACCOUNTMANAGER_HUBSPOTID,
 			Source = Sources.HubSpot
@@ -59,7 +59,7 @@ public class AccountManagerDealTests
 	public void Deactivate_IsActiveIsTrue_SetIsActiveToFalse()
 	{
 		// Arrange
-		AccountManagerDeal accountManagerDeal = new(Guid.NewGuid())
+		AccountManagerDeal accountManagerDeal = new()
 		{
 			IsActive = true,
 		};
@@ -75,7 +75,7 @@ public class AccountManagerDealTests
 	public void Deactivate_IsActiveIsFalse_IsActiveStillFalse()
 	{
 		// Arrange
-		AccountManagerDeal accountManagerDeal = new(Guid.NewGuid())
+		AccountManagerDeal accountManagerDeal = new()
 		{
 			IsActive = false,
 		};

--- a/test/Pelican.Domain.Test/Entities/AccountManagerUnitTest.cs
+++ b/test/Pelican.Domain.Test/Entities/AccountManagerUnitTest.cs
@@ -8,7 +8,7 @@ public class AccountManagerUnitTest
 	private readonly AccountManager _uut;
 	public AccountManagerUnitTest()
 	{
-		_uut = new AccountManager(Guid.NewGuid());
+		_uut = new AccountManager();
 	}
 
 	[Fact]

--- a/test/Pelican.Domain.Test/Entities/ClientContactUnitTest.cs
+++ b/test/Pelican.Domain.Test/Entities/ClientContactUnitTest.cs
@@ -12,13 +12,13 @@ public class ClientContactUnitTest
 		const string CLIENT_HUBSPOTID = "clienthubspotid";
 		const string CONTACT_HUBSPOTID = "contacthubspotid";
 
-		Client client = new(Guid.NewGuid())
+		Client client = new()
 		{
 			SourceId = CLIENT_HUBSPOTID,
 			Source = Sources.HubSpot
 		};
 
-		Contact contact = new(Guid.NewGuid())
+		Contact contact = new()
 		{
 			SourceId = CONTACT_HUBSPOTID,
 			Source = Sources.HubSpot

--- a/test/Pelican.Domain.Test/Entities/ClientUnitTest.cs
+++ b/test/Pelican.Domain.Test/Entities/ClientUnitTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Pelican.Domain.Test.Entities;
 public class ClientUnitTest
 {
-	private readonly Client _uut = new Client(Guid.NewGuid())
+	private readonly Client _uut = new Client()
 	{
 		SourceId = "uutHubSpotId",
 		Source = Sources.HubSpot
@@ -176,7 +176,7 @@ public class ClientUnitTest
 	public void UpdateClientContacts_EmptyExistingClientContactArgumentNotNull_NewClientContactAdded()
 	{
 		// Arrange
-		Contact newContact = new(Guid.NewGuid())
+		Contact newContact = new()
 		{
 			SourceId = "newHubSpotId",
 		};
@@ -199,7 +199,7 @@ public class ClientUnitTest
 	public void UpdateClientContacts_OneExistingClientContactNotInArgument_ClientContactsUpdated()
 	{
 		// Arrange
-		Contact existingContact = new(Guid.NewGuid())
+		Contact existingContact = new()
 		{
 			SourceId = "hsId",
 			Source = Sources.HubSpot
@@ -209,9 +209,9 @@ public class ClientUnitTest
 
 		ICollection<ClientContact> clientContacts = new List<ClientContact>()
 		{
-			new(Guid.NewGuid())
+			new()
 			{
-				Contact=new(Guid.NewGuid()),
+				Contact=new(),
 			}
 		};
 
@@ -235,7 +235,7 @@ public class ClientUnitTest
 	public void UpdateClientContacts_OneExistingClientContactMatchInArgument_NoClientContactAddedExistingClientContactStillActive()
 	{
 		// Arrange
-		Contact existingContact = new(Guid.NewGuid())
+		Contact existingContact = new()
 		{
 			SourceId = "hsId",
 			Source = Sources.HubSpot,
@@ -243,7 +243,7 @@ public class ClientUnitTest
 
 		_uut.ClientContacts.Add(ClientContact.Create(_uut, existingContact));
 
-		Contact newContact = new(Guid.NewGuid())
+		Contact newContact = new()
 		{
 			SourceId = "hsId",
 			Source = Sources.HubSpot,

--- a/test/Pelican.Domain.Test/Entities/ContactTests.cs
+++ b/test/Pelican.Domain.Test/Entities/ContactTests.cs
@@ -415,7 +415,7 @@ public class ContactTests
 	public void UpdateDealContacts_EmptyExistingDealContactArgumentNotNull_NewDealContactAdded()
 	{
 		// Arrange
-		Deal newDeal = new(Guid.NewGuid())
+		Deal newDeal = new()
 		{
 			SourceId = "newHubSpotId",
 		};
@@ -438,7 +438,7 @@ public class ContactTests
 	public void UpdateDealContacts_OneExistingDealContactNotInArgument_DealContactsUpdated()
 	{
 		// Arrange
-		Deal existingDeal = new(Guid.NewGuid())
+		Deal existingDeal = new()
 		{
 			SourceId = "hsId",
 			Source = Sources.HubSpot,
@@ -448,9 +448,9 @@ public class ContactTests
 
 		ICollection<DealContact> dealContacts = new List<DealContact>()
 		{
-			new(Guid.NewGuid())
+			new()
 			{
-				Deal=new(Guid.NewGuid()),
+				Deal=new(),
 			}
 		};
 
@@ -469,7 +469,7 @@ public class ContactTests
 	public void UpdateDealContacts_OneExistingDealContactMatchInArgument_NoDealContactAdded()
 	{
 		// Arrange
-		Deal existingDeal = new(Guid.NewGuid())
+		Deal existingDeal = new()
 		{
 			SourceId = "hsId",
 			Source = Sources.HubSpot,
@@ -477,7 +477,7 @@ public class ContactTests
 
 		_uut.DealContacts.Add(DealContact.Create(existingDeal, _uut));
 
-		Deal newDeal = new(Guid.NewGuid())
+		Deal newDeal = new()
 		{
 			SourceId = "hsId",
 			Source = Sources.HubSpot,
@@ -501,7 +501,7 @@ public class ContactTests
 	public void UpdateDealContacts_OneExistingDealContactMatchInArgument_DealContactStillActive()
 	{
 		// Arrange
-		Deal existingDeal = new(Guid.NewGuid())
+		Deal existingDeal = new()
 		{
 			SourceId = "hsId",
 			Source = Sources.HubSpot,
@@ -509,7 +509,7 @@ public class ContactTests
 
 		_uut.DealContacts.Add(DealContact.Create(existingDeal, _uut));
 
-		Deal newDeal = new(Guid.NewGuid())
+		Deal newDeal = new()
 		{
 			SourceId = "hsId",
 			Source = Sources.HubSpot,

--- a/test/Pelican.Domain.Test/Entities/DealContactTests.cs
+++ b/test/Pelican.Domain.Test/Entities/DealContactTests.cs
@@ -12,13 +12,13 @@ public class DealContactTests
 		const string DEAL_HUBSPOTID = "dealhubspotid";
 		const string CONTACT_HUBSPOTID = "contacthubspotid";
 
-		Deal deal = new(Guid.NewGuid())
+		Deal deal = new()
 		{
 			SourceId = DEAL_HUBSPOTID,
 			Source = Sources.HubSpot,
 		};
 
-		Contact contact = new(Guid.NewGuid())
+		Contact contact = new()
 		{
 			SourceId = CONTACT_HUBSPOTID,
 			Source = Sources.HubSpot,
@@ -59,7 +59,7 @@ public class DealContactTests
 	public void Deactivate_IsActiveIsTrue_SetIsActiveToFalse()
 	{
 		// Arrange
-		DealContact dealContact = new(Guid.NewGuid())
+		DealContact dealContact = new()
 		{
 			IsActive = true,
 		};
@@ -75,7 +75,7 @@ public class DealContactTests
 	public void Deactivate_IsActiveIsFalse_IsActiveStillFalse()
 	{
 		// Arrange
-		DealContact dealContact = new(Guid.NewGuid())
+		DealContact dealContact = new()
 		{
 			IsActive = false,
 		};

--- a/test/Pelican.Domain.Test/Entities/DealTests.cs
+++ b/test/Pelican.Domain.Test/Entities/DealTests.cs
@@ -112,7 +112,7 @@ public class DealTests
 
 		string value = "";
 
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		/// Act
 		Exception exceptionResult = Record.Exception(() => inputDeal.UpdateProperty(name, value));
@@ -135,7 +135,7 @@ public class DealTests
 
 		string value = "Hello";
 
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		/// Act
 		Exception exceptionResult = Record.Exception(() => inputDeal.UpdateProperty(name, value));
@@ -158,7 +158,7 @@ public class DealTests
 
 		string value = ticks.ToString();
 
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		/// Act
 		Deal returnDeal = inputDeal.UpdateProperty(name, value);
@@ -176,7 +176,7 @@ public class DealTests
 
 		string value = "Hello";
 
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		/// Act
 		Exception exceptionResult = Record.Exception(() => inputDeal.UpdateProperty(name, value));
@@ -199,7 +199,7 @@ public class DealTests
 
 		string value = ticks.ToString();
 
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		/// Act
 		Deal returnDeal = inputDeal.UpdateProperty(name, value);
@@ -217,7 +217,7 @@ public class DealTests
 
 		string value = "Hello";
 
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		/// Act
 		Exception exceptionResult = Record.Exception(() => inputDeal.UpdateProperty(name, value));
@@ -240,7 +240,7 @@ public class DealTests
 
 		string value = ticks.ToString();
 
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		// Act
 		Deal returnDeal = inputDeal.UpdateProperty(name, value);
@@ -258,7 +258,7 @@ public class DealTests
 		string name = "dealstage";
 		string value = "newStatus";
 
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		/// Act
 		Deal returnDeal = inputDeal.UpdateProperty(name, value);
@@ -276,7 +276,7 @@ public class DealTests
 		string name = "description";
 		string value = "newDescription";
 
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		/// Act
 		Deal returnDeal = inputDeal.UpdateProperty(name, value);
@@ -294,7 +294,7 @@ public class DealTests
 		string name = "dealname";
 		string value = "newName";
 
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		/// Act
 		Deal returnDeal = inputDeal.UpdateProperty(name, value);
@@ -360,7 +360,7 @@ public class DealTests
 	public void UpdateAccountManager_AccountManagerDealsEmptyArgNull_EmptyAccountManagerDeals()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		// Act
 		inputDeal.UpdateAccountManager(null);
@@ -375,7 +375,7 @@ public class DealTests
 	public void UpdateAccountManager_ActiveAccountManagerDealEmptyArgNull_NullActiveAccountManagerDeal()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 		inputDeal.AccountManagerDeals.Add(new() { IsActive = true });
 
 		// Act
@@ -393,7 +393,7 @@ public class DealTests
 	public void UpdateAccountManager_AccountManagerDealsEmptyArgNewAccountManagerDeal_AccountManagerDealAddedAsActive()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		AccountManager accountManager = new();
 
@@ -414,11 +414,11 @@ public class DealTests
 	public void UpdateAccountManager_AccountManagerDealsNotEmptyArgNewAccountManagerDeal_AccountManagerDealAddedAsActive()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid())
+		Deal inputDeal = new()
 		{
 			AccountManagerDeals = new List<AccountManagerDeal>()
 			{
-				new(Guid.NewGuid())
+				new()
 				{
 					IsActive = true,
 					SourceAccountManagerId = "first",
@@ -445,7 +445,7 @@ public class DealTests
 	public void SetAccountManager_AccountManagerDealsEmptyArgNull_EmptyAccountManagerDeals()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		// Act
 		inputDeal.SetAccountManager(null);
@@ -460,7 +460,7 @@ public class DealTests
 	public void SetAccountManager_AccountManagerDealsEmptyArgNewAccountManagerDeal_AccountManagerDealAddedAsActive()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		AccountManager accountManager = new();
 
@@ -481,7 +481,7 @@ public class DealTests
 	public void SetContacts_DealContactsEmptyArgsNull_DealContactsEmpty()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		// Act
 		inputDeal.SetContacts(null);
@@ -496,7 +496,7 @@ public class DealTests
 	public void SetContacts_DealContactsEmptyArgsEmptyList_DealContactsEmpty()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		// Act
 		inputDeal.SetContacts(new List<Contact>());
@@ -511,7 +511,7 @@ public class DealTests
 	public void SetContacts_DealContactsEmptyArgsNonEmptyList_DealContactsSet()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		// Act
 		inputDeal.SetContacts(new List<Contact>() { new() });
@@ -526,7 +526,7 @@ public class DealTests
 	public void SetContacts_DealContactsEmptyArgsListContainingNull_DealContactsSet()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		// Act
 		inputDeal.SetContacts(new List<Contact?>() { new(), null });
@@ -541,7 +541,7 @@ public class DealTests
 	public void SetClient_ArgNull_ClientAndClientIdNull()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
 		// Act
 		inputDeal.SetClient(null);
@@ -555,9 +555,9 @@ public class DealTests
 	public void SetClient_ArgNewClient_ClientAndClientIdSet()
 	{
 		// Arrange
-		Deal inputDeal = new(Guid.NewGuid());
+		Deal inputDeal = new();
 
-		Client client = new(Guid.NewGuid());
+		Client client = new();
 		// Act
 		inputDeal.SetClient(client);
 

--- a/test/Pelican.Domain.Test/Entities/SupplierUnitTest.cs
+++ b/test/Pelican.Domain.Test/Entities/SupplierUnitTest.cs
@@ -8,7 +8,7 @@ public class SupplierUnitTest
 	private readonly Supplier _uut;
 	public SupplierUnitTest()
 	{
-		_uut = new Supplier(Guid.NewGuid());
+		_uut = new Supplier();
 	}
 	[Fact]
 	public void SetName_NameStringNotToLong_NameEqualToValueSet()

--- a/test/Pelican.Presentation.GraphQL.Test/AccountManagersQueryUnitTest.cs
+++ b/test/Pelican.Presentation.GraphQL.Test/AccountManagersQueryUnitTest.cs
@@ -33,7 +33,7 @@ public class AccountManagersQueryUnitTest
 
 		_mediatorMock
 			.Setup(x => x.Send(input, default))
-			.ReturnsAsync(new AccountManager(id));
+			.ReturnsAsync(new AccountManager() { Id = id });
 
 		//Act
 		var result = await _uut.GetAccountManagerAsync(

--- a/test/Pelican.Presentation.GraphQL.Test/ClientsQueryUnitTest.cs
+++ b/test/Pelican.Presentation.GraphQL.Test/ClientsQueryUnitTest.cs
@@ -34,7 +34,7 @@ public class ClientsQueryUnitTest
 
 		_mediatorMock
 			.Setup(x => x.Send(input, default))
-			.ReturnsAsync(new Client(id));
+			.ReturnsAsync(new Client() { Id = id });
 
 		//Act
 		var result = await _uut.GetClientAsync(

--- a/test/Pelican.Presentation.GraphQL.Test/GetContactsQueryUnitTest.cs
+++ b/test/Pelican.Presentation.GraphQL.Test/GetContactsQueryUnitTest.cs
@@ -33,7 +33,7 @@ public class GetContactsQueryUnitTest
 
 		_mediatorMock
 			.Setup(x => x.Send(input, default))
-			.ReturnsAsync(new Contact(id));
+			.ReturnsAsync(new Contact() { Id = id });
 
 		//Act
 		var result = await _uut.GetContactAsync(

--- a/test/Pelican.Presentation.GraphQL.Test/GetDealsQueryUnitTest.cs
+++ b/test/Pelican.Presentation.GraphQL.Test/GetDealsQueryUnitTest.cs
@@ -35,7 +35,7 @@ public class GetDealsQueryUnitTest
 
 		_mediatorMock
 			.Setup(x => x.Send(input, default))
-			.ReturnsAsync(new Deal(id));
+			.ReturnsAsync(new Deal() { Id = id });
 
 		//Act
 		var result = await uut.GetDealAsync(

--- a/test/Pelican.Presentation.GraphQL.Test/GetSuppliersQueryUnitTest.cs
+++ b/test/Pelican.Presentation.GraphQL.Test/GetSuppliersQueryUnitTest.cs
@@ -35,7 +35,7 @@ public class GetSuppliersQueryUnitTest
 
 		_mediatorMock
 			.Setup(x => x.Send(input, default))
-			.ReturnsAsync(new Supplier(id));
+			.ReturnsAsync(new Supplier() { Id = id });
 
 		//Act
 		var result = await uut.GetSupplierAsync(


### PR DESCRIPTION
Constructors with id parameter is only used in tests and should not be used in source code therefore the constructor is removed. 

All changes should only be removing the id when instantiating an object so it should be pretty easy to review even though lots of files is changed. 