### PR TITLE
Feature/plcn 322 create role enum

### DIFF
--- a/src/Pelican.Domain/Enums/RoleEnum.cs
+++ b/src/Pelican.Domain/Enums/RoleEnum.cs
@@ -3,5 +3,5 @@
 public enum RoleEnum
 {
 	Admin = 0,
-	User = 1,
+	Standard = 1,
 }

--- a/src/Pelican.Domain/Enums/RoleEnum.cs
+++ b/src/Pelican.Domain/Enums/RoleEnum.cs
@@ -1,0 +1,7 @@
+﻿namespace Pelican.Domain.Enums;
+
+public enum RoleEnum
+{
+	Admin = 0,
+	User = 1,
+}


### PR DESCRIPTION
An enum has been created so that we can assign the role of either Admin or Standard to an user.