### PR TITLE
Feature/plcn 330 create token options

### DIFF
--- a/src/Pelican.App/Program.cs
+++ b/src/Pelican.App/Program.cs
@@ -11,7 +11,7 @@ const string ALLOW_ALL = "AllowAll";
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDomain(builder.Configuration, builder.Environment.IsProduction());
 builder.Services.AddPersistince(builder.Configuration, builder.Environment.IsProduction());
-builder.Services.AddApplication();
+builder.Services.AddApplication(builder.Configuration);
 builder.Services.AddHubSpot();
 
 builder.Services.AddCors(options =>

--- a/src/Pelican.App/appsettings.json
+++ b/src/Pelican.App/appsettings.json
@@ -42,4 +42,8 @@
 	"PipedriveDevSettings": {
 		"RedirectUrl": "https://localhost:7119/Pipedrive"
 	}
+
+	"Tokens": {
+		"Secret":  "TokenSecret"
+	}
 }

--- a/src/Pelican.Application/DependencyInjection.cs
+++ b/src/Pelican.Application/DependencyInjection.cs
@@ -2,9 +2,11 @@
 using System.Runtime.CompilerServices;
 using FluentValidation;
 using MediatR;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Application.Behaviours;
+using Pelican.Application.Options;
 using Pelican.Application.RestSharp;
 using Pelican.Domain.Settings.HubSpot;
 
@@ -14,7 +16,7 @@ namespace Pelican.Application;
 public static class DependencyInjection
 {
 	//Add application as a service that can be used in program
-	public static IServiceCollection AddApplication(this IServiceCollection services)
+	public static IServiceCollection AddApplication(this IServiceCollection services, IConfiguration configuration)
 	{
 		services.AddSingleton<IClient<HubSpotSettings>, RestSharpClient<HubSpotSettings>>();
 
@@ -23,6 +25,8 @@ public static class DependencyInjection
 		services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 
 		services.AddScoped(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
+
+		services.Configure<TokenOptions>(configuration.GetSection(TokenOptions.Tokens));
 
 		return services;
 	}

--- a/src/Pelican.Application/Options/TokenOptions.cs
+++ b/src/Pelican.Application/Options/TokenOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace Pelican.Application.Options;
+public class TokenOptions
+{
+	public const string Tokens = "Tokens";
+	public string Secret = "VERY_SECRET_SECRET";
+}


### PR DESCRIPTION
Created a token options class which can be used by the TokenService which will be implemented later. The Secret of the TokenOptions will later be overwritten by a secret stored in azure currently it contains a placeholder.