### PR TITLE
Feature/plcn 393 handle hubspot pagination when fetching data

### DIFF
--- a/src/Pelican.Application/Abstractions/Infrastructure/IResponse.cs
+++ b/src/Pelican.Application/Abstractions/Infrastructure/IResponse.cs
@@ -5,6 +5,8 @@ namespace Pelican.Application.Abstractions.Infrastructure;
 
 public interface IResponse<TResponse>
 {
+	TResponse? Data { get; }
+
 	Result<TResult> GetResult<TResult>(Func<TResponse, TResult> mappingFunc);
 
 	Task<Result<TResult>> GetResultWithUnitOfWork<TResult>(

--- a/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/AccountManagers/OwnersResponse.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/AccountManagers/OwnersResponse.cs
@@ -1,9 +1,0 @@
-﻿using System.Text.Json.Serialization;
-
-namespace Pelican.Infrastructure.HubSpot.Contracts.Responses.AccountManagers;
-
-internal sealed class OwnersResponse
-{
-	[JsonPropertyName("results")]
-	public IEnumerable<OwnerResponse> Results { get; set; } = Enumerable.Empty<OwnerResponse>();
-}

--- a/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Clients/CompaniesResponse.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Clients/CompaniesResponse.cs
@@ -1,9 +1,0 @@
-﻿using System.Text.Json.Serialization;
-
-namespace Pelican.Infrastructure.HubSpot.Contracts.Responses.Clients;
-
-internal sealed class CompaniesResponse
-{
-	[JsonPropertyName("results")]
-	public IEnumerable<CompanyResponse> Results { get; set; } = Enumerable.Empty<CompanyResponse>();
-}

--- a/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Common/Next.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Common/Next.cs
@@ -1,0 +1,9 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
+
+internal sealed class Next
+{
+	[JsonPropertyName("after")]
+	public string After { get; set; } = string.Empty;
+}

--- a/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Common/PaginatedResponse.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Common/PaginatedResponse.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
+
+internal sealed class PaginatedResponse<TResponse>
+{
+	[JsonPropertyName("results")]
+	public IEnumerable<TResponse> Results { get; set; } = Enumerable.Empty<TResponse>();
+
+	[JsonPropertyName("paging")]
+	public Paging Paging { get; set; } = new();
+}

--- a/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Common/Paging.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Common/Paging.cs
@@ -1,0 +1,9 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
+
+internal sealed class Paging
+{
+	[JsonPropertyName("next")]
+	public Next Next { get; set; } = new();
+}

--- a/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Contacts/ContactsResponse.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Contacts/ContactsResponse.cs
@@ -1,9 +1,0 @@
-﻿using System.Text.Json.Serialization;
-
-namespace Pelican.Infrastructure.HubSpot.Contracts.Responses.Contacts;
-
-internal sealed class ContactsResponse
-{
-	[JsonPropertyName("results")]
-	public IEnumerable<ContactResponse> Results { get; set; } = Enumerable.Empty<ContactResponse>();
-}

--- a/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Deals/DealsResponse.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Contracts/Responses/Deals/DealsResponse.cs
@@ -1,9 +1,0 @@
-﻿using System.Text.Json.Serialization;
-
-namespace Pelican.Infrastructure.HubSpot.Contracts.Responses.Deals;
-
-internal sealed class DealsResponse
-{
-	[JsonPropertyName("results")]
-	public IEnumerable<DealResponse> Results { get; set; } = Enumerable.Empty<DealResponse>();
-}

--- a/src/Pelican.Infrastructure.HubSpot/Extensions/ResponseExtension.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Extensions/ResponseExtension.cs
@@ -1,0 +1,12 @@
+﻿using Pelican.Application.Abstractions.Infrastructure;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Deals;
+
+namespace Pelican.Infrastructure.HubSpot.Extensions;
+
+internal static class ResponseExtension
+{
+	internal static string After<TResponse>(this IResponse<PaginatedResponse<TResponse>> response)
+		where TResponse : class
+		=> response.Data?.Paging.Next.After ?? string.Empty;
+}

--- a/src/Pelican.Infrastructure.HubSpot/Mapping/AccountManagers/OwnersResponseToAccountManagers.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Mapping/AccountManagers/OwnersResponseToAccountManagers.cs
@@ -1,11 +1,12 @@
 ﻿using Pelican.Domain.Entities;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.AccountManagers;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 
 namespace Pelican.Infrastructure.HubSpot.Mapping.AccountManagers;
 
 internal static class OwnersResponseToAccountManagers
 {
-	internal static List<AccountManager> ToAccountManagers(this OwnersResponse responses)
+	internal static List<AccountManager> ToAccountManagers(this PaginatedResponse<OwnerResponse> responses)
 	{
 		if (responses.Results is null)
 		{

--- a/src/Pelican.Infrastructure.HubSpot/Mapping/Clients/CompaniesResponseToClients.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Mapping/Clients/CompaniesResponseToClients.cs
@@ -1,13 +1,14 @@
 ﻿using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Domain.Entities;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Clients;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 
 namespace Pelican.Infrastructure.HubSpot.Mapping.Clients;
 
 internal static class CompaniesResponseToClients
 {
 	internal static async Task<List<Client>> ToClients(
-		this CompaniesResponse responses,
+		this PaginatedResponse<CompanyResponse> responses,
 		IUnitOfWork unitOfWork,
 		CancellationToken cancellationToken)
 	{

--- a/src/Pelican.Infrastructure.HubSpot/Mapping/Contacts/ContactsResponseToContacts.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Mapping/Contacts/ContactsResponseToContacts.cs
@@ -1,5 +1,6 @@
 ﻿using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Domain.Entities;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Contacts;
 
 namespace Pelican.Infrastructure.HubSpot.Mapping.Contacts;
@@ -7,7 +8,7 @@ namespace Pelican.Infrastructure.HubSpot.Mapping.Contacts;
 internal static class ContactsResponseToContacts
 {
 	internal static async Task<List<Contact>> ToContacts(
-		this ContactsResponse responses,
+		this PaginatedResponse<ContactResponse> responses,
 		IUnitOfWork unitOfWork,
 		CancellationToken cancellationToken)
 	{

--- a/src/Pelican.Infrastructure.HubSpot/Mapping/Deals/DealsResponseToDeals.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Mapping/Deals/DealsResponseToDeals.cs
@@ -1,5 +1,7 @@
 ﻿using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.RestSharp;
 using Pelican.Domain.Entities;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Deals;
 
 namespace Pelican.Infrastructure.HubSpot.Mapping.Deals;
@@ -7,7 +9,7 @@ namespace Pelican.Infrastructure.HubSpot.Mapping.Deals;
 internal static class DealsResponseToDeals
 {
 	internal static async Task<List<Deal>> ToDeals(
-		this DealsResponse responses,
+		this PaginatedResponse<DealResponse> responses,
 		IUnitOfWork unitOfWork,
 		CancellationToken cancellationToken)
 	{

--- a/src/Pelican.Infrastructure.HubSpot/Pelican.Infrastructure.HubSpot.csproj
+++ b/src/Pelican.Infrastructure.HubSpot/Pelican.Infrastructure.HubSpot.csproj
@@ -10,4 +10,8 @@
 		<ProjectReference Include="..\Pelican.Application\Pelican.Application.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+	</ItemGroup>
+
 </Project>

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAccountManagerService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAccountManagerService.cs
@@ -5,6 +5,7 @@ using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.AccountManagers;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Mapping.AccountManagers;
 using RestSharp;
 
@@ -41,8 +42,8 @@ internal sealed class HubSpotAccountManagerService : ServiceBase<HubSpotSettings
 		RestRequest request = new RestRequest("crm/v3/owners")
 			.AddHeader("Authorization", $"Bearer {accessToken}");
 
-		IResponse<OwnersResponse> response = await _client
-			.GetAsync<OwnersResponse>(request, cancellationToken);
+		IResponse<PaginatedResponse<OwnerResponse>> response = await _client
+			.GetAsync<PaginatedResponse<OwnerResponse>>(request, cancellationToken);
 
 		return response
 			.GetResult(OwnersResponseToAccountManagers.ToAccountManagers);

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAccountManagerService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAccountManagerService.cs
@@ -9,7 +9,6 @@ using Pelican.Infrastructure.HubSpot.Contracts.Responses.AccountManagers;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Extensions;
 using Pelican.Infrastructure.HubSpot.Mapping.AccountManagers;
-using Pelican.Infrastructure.HubSpot.Mapping.Deals;
 using RestSharp;
 
 namespace Pelican.Infrastructure.HubSpot.Services;
@@ -50,12 +49,9 @@ internal sealed class HubSpotAccountManagerService : ServiceBase<HubSpotSettings
 					OwnersResponseToAccountManagers.ToAccountManagers))
 			.ToArray();
 
-		if ((Result.FirstFailureOrSuccess(results) is Result result) && result.IsFailure)
-		{
-			return (Result<List<AccountManager>>)result;
-		}
-
-		return results.SelectMany(r => r.Value).ToList();
+		return Result.FirstFailureOrSuccess(results) is Result result && result.IsFailure
+			? (Result<List<AccountManager>>)result
+			: results.SelectMany(r => r.Value).ToList();
 	}
 
 	private async IAsyncEnumerable<IResponse<PaginatedResponse<OwnerResponse>>> GetAllPages(

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAuthorizationService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotAuthorizationService.cs
@@ -47,7 +47,7 @@ internal sealed class HubSpotAuthorizationService : ServiceBase<HubSpotSettings>
 		string accessToken,
 		CancellationToken cancellationToken)
 	{
-		RestRequest request = new RestRequest($"oauth/v1/access-tokens/{accessToken}");
+		RestRequest request = new($"oauth/v1/access-tokens/{accessToken}");
 
 		IResponse<AccessTokenResponse> response = await _client
 			.GetAsync<AccessTokenResponse>(request, cancellationToken);

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotClientService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotClientService.cs
@@ -1,10 +1,10 @@
-﻿using Pelican.Application.Abstractions.Data.Repositories;
+﻿using System.Runtime.CompilerServices;
+using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.HubSpot;
 using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
-using Pelican.Infrastructure.HubSpot.Contracts.Responses.AccountManagers;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Clients;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Extensions;
@@ -44,17 +44,45 @@ internal sealed class HubSpotClientService : ServiceBase<HubSpotSettings>, IHubS
 		string accessToken,
 		CancellationToken cancellationToken)
 	{
-		RestRequest request = new RestRequest("crm/v4/objects/companies")
-			.AddHeader("Authorization", $"Bearer {accessToken}")
-			.AddCompanyQueryParams();
+		var responses = await GetAllPages(accessToken, cancellationToken).ToListAsync(cancellationToken);
 
-		IResponse<PaginatedResponse<CompanyResponse>> response = await _client
-			.GetAsync<PaginatedResponse<CompanyResponse>>(request, cancellationToken);
+		var results = responses
+			.Select(response => response
+				.GetResultWithUnitOfWork(
+					CompaniesResponseToClients.ToClients,
+					_unitOfWork,
+					cancellationToken))
+			.Select(t => t.Result)
+			.ToArray();
 
-		return await response
-			.GetResultWithUnitOfWork(
-				CompaniesResponseToClients.ToClients,
-				_unitOfWork,
-				cancellationToken);
+		if ((Result.FirstFailureOrSuccess(results) is Result result) && result.IsFailure)
+		{
+			return (Result<List<Client>>)result;
+		}
+
+		return results.SelectMany(r => r.Value).ToList();
+	}
+
+	private async IAsyncEnumerable<IResponse<PaginatedResponse<CompanyResponse>>> GetAllPages(
+		string accessToken,
+		[EnumeratorCancellation] CancellationToken cancellationToken)
+	{
+		string after = "0";
+		while (!string.IsNullOrWhiteSpace(after))
+		{
+			RestRequest request = new RestRequest("crm/v4/objects/companies")
+				.AddHeader("Authorization", $"Bearer {accessToken}")
+				.AddCompanyQueryParams()
+				.AddQueryParameter("after", after, false);
+
+			IResponse<PaginatedResponse<CompanyResponse>> responses = await _client
+				.GetAsync<PaginatedResponse<CompanyResponse>>(
+					request,
+					cancellationToken);
+
+			after = responses.After();
+
+			yield return responses;
+		}
 	}
 }

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotClientService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotClientService.cs
@@ -55,12 +55,9 @@ internal sealed class HubSpotClientService : ServiceBase<HubSpotSettings>, IHubS
 			.Select(t => t.Result)
 			.ToArray();
 
-		if ((Result.FirstFailureOrSuccess(results) is Result result) && result.IsFailure)
-		{
-			return (Result<List<Client>>)result;
-		}
-
-		return results.SelectMany(r => r.Value).ToList();
+		return Result.FirstFailureOrSuccess(results) is Result result && result.IsFailure
+			? (Result<List<Client>>)result
+			: results.SelectMany(r => r.Value).ToList();
 	}
 
 	private async IAsyncEnumerable<IResponse<PaginatedResponse<CompanyResponse>>> GetAllPages(

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotClientService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotClientService.cs
@@ -4,7 +4,9 @@ using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.AccountManagers;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Clients;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Extensions;
 using Pelican.Infrastructure.HubSpot.Mapping.Clients;
 using RestSharp;
@@ -46,8 +48,8 @@ internal sealed class HubSpotClientService : ServiceBase<HubSpotSettings>, IHubS
 			.AddHeader("Authorization", $"Bearer {accessToken}")
 			.AddCompanyQueryParams();
 
-		IResponse<CompaniesResponse> response = await _client
-			.GetAsync<CompaniesResponse>(request, cancellationToken);
+		IResponse<PaginatedResponse<CompanyResponse>> response = await _client
+			.GetAsync<PaginatedResponse<CompanyResponse>>(request, cancellationToken);
 
 		return await response
 			.GetResultWithUnitOfWork(

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotContactService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotContactService.cs
@@ -4,6 +4,7 @@ using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Contacts;
 using Pelican.Infrastructure.HubSpot.Extensions;
 using Pelican.Infrastructure.HubSpot.Mapping.Contacts;
@@ -48,8 +49,8 @@ internal sealed class HubSpotContactService : ServiceBase<HubSpotSettings>, IHub
 			.AddHeader("Authorization", $"Bearer {accessToken}")
 			.AddContactQueryParams();
 
-		IResponse<ContactsResponse> response = await _client
-			.GetAsync<ContactsResponse>(request, cancellationToken);
+		IResponse<PaginatedResponse<ContactResponse>> response = await _client
+			.GetAsync<PaginatedResponse<ContactResponse>>(request, cancellationToken);
 
 		return await response
 			.GetResultWithUnitOfWork(

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotContactService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotContactService.cs
@@ -56,12 +56,9 @@ internal sealed class HubSpotContactService : ServiceBase<HubSpotSettings>, IHub
 			.Select(t => t.Result)
 			.ToArray();
 
-		if ((Result.FirstFailureOrSuccess(results) is Result result) && result.IsFailure)
-		{
-			return (Result<List<Contact>>)result;
-		}
-
-		return results.SelectMany(r => r.Value).ToList();
+		return Result.FirstFailureOrSuccess(results) is Result result && result.IsFailure
+			? (Result<List<Contact>>)result
+			: results.SelectMany(r => r.Value).ToList();
 	}
 
 

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotDealService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotDealService.cs
@@ -1,9 +1,17 @@
-﻿using Pelican.Application.Abstractions.Data.Repositories;
+﻿using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Azure.Core;
+using HotChocolate.Configuration;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
+using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.HubSpot;
 using Pelican.Application.Abstractions.Infrastructure;
+using Pelican.Application.RestSharp;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Deals;
 using Pelican.Infrastructure.HubSpot.Extensions;
 using Pelican.Infrastructure.HubSpot.Mapping.Deals;
@@ -44,19 +52,45 @@ internal sealed class HubSpotDealService : ServiceBase<HubSpotSettings>, IHubSpo
 		string accessToken,
 		CancellationToken cancellationToken)
 	{
-		RestRequest request = new RestRequest("crm/v4/objects/deals")
-			.AddHeader("Authorization", $"Bearer {accessToken}")
-			.AddDealQueryParams();
+		var responses = await GetAllPages(accessToken, cancellationToken).ToListAsync(cancellationToken);
 
-		IResponse<DealsResponse> response = await _client
-			.GetAsync<DealsResponse>(
-				request,
-				cancellationToken);
+		var results = responses
+			.Select(response => response
+				.GetResultWithUnitOfWork(
+					DealsResponseToDeals.ToDeals,
+					_unitOfWork,
+					cancellationToken))
+			.Select(t => t.Result)
+			.ToArray();
 
-		return await response
-			.GetResultWithUnitOfWork(
-				DealsResponseToDeals.ToDeals,
-				_unitOfWork,
-				cancellationToken);
+		if (Result.FirstFailureOrSuccess(results) is Result<List<Deal>> result)
+		{
+			return result;
+		}
+
+		return results.SelectMany(r => r.Value).ToList();
+	}
+
+	private async IAsyncEnumerable<IResponse<PaginatedResponse<DealResponse>>> GetAllPages(
+		string accessToken,
+		[EnumeratorCancellation] CancellationToken cancellationToken)
+	{
+		string after = "0";
+		while (!string.IsNullOrWhiteSpace(after))
+		{
+			RestRequest request = new RestRequest("crm/v4/objects/deals")
+				.AddHeader("Authorization", $"Bearer {accessToken}")
+				.AddDealQueryParams()
+				.AddQueryParameter("after", after, false);
+
+			IResponse<PaginatedResponse<DealResponse>> responses = await _client
+				.GetAsync<PaginatedResponse<DealResponse>>(
+					request,
+					cancellationToken);
+
+			after = responses.After<DealResponse>();
+
+			yield return responses;
+		}
 	}
 }

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotDealService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotDealService.cs
@@ -1,13 +1,7 @@
-﻿using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using Azure.Core;
-using HotChocolate.Configuration;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
+﻿using System.Runtime.CompilerServices;
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.HubSpot;
 using Pelican.Application.Abstractions.Infrastructure;
-using Pelican.Application.RestSharp;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
@@ -63,9 +57,9 @@ internal sealed class HubSpotDealService : ServiceBase<HubSpotSettings>, IHubSpo
 			.Select(t => t.Result)
 			.ToArray();
 
-		if (Result.FirstFailureOrSuccess(results) is Result<List<Deal>> result)
+		if ((Result.FirstFailureOrSuccess(results) is Result result) && result.IsFailure)
 		{
-			return result;
+			return (Result<List<Deal>>)result;
 		}
 
 		return results.SelectMany(r => r.Value).ToList();
@@ -88,7 +82,7 @@ internal sealed class HubSpotDealService : ServiceBase<HubSpotSettings>, IHubSpo
 					request,
 					cancellationToken);
 
-			after = responses.After<DealResponse>();
+			after = responses.After();
 
 			yield return responses;
 		}

--- a/src/Pelican.Infrastructure.HubSpot/Services/HubSpotDealService.cs
+++ b/src/Pelican.Infrastructure.HubSpot/Services/HubSpotDealService.cs
@@ -57,12 +57,9 @@ internal sealed class HubSpotDealService : ServiceBase<HubSpotSettings>, IHubSpo
 			.Select(t => t.Result)
 			.ToArray();
 
-		if ((Result.FirstFailureOrSuccess(results) is Result result) && result.IsFailure)
-		{
-			return (Result<List<Deal>>)result;
-		}
-
-		return results.SelectMany(r => r.Value).ToList();
+		return Result.FirstFailureOrSuccess(results) is Result result && result.IsFailure
+			? (Result<List<Deal>>)result
+			: results.SelectMany(r => r.Value).ToList();
 	}
 
 	private async IAsyncEnumerable<IResponse<PaginatedResponse<DealResponse>>> GetAllPages(

--- a/test/Pelican.Infrastructure.HubSpot.Test/Mapping/AccountManagers/OwnersResponseToAccountManagersTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Mapping/AccountManagers/OwnersResponseToAccountManagersTests.cs
@@ -1,5 +1,6 @@
 ﻿using Pelican.Domain;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.AccountManagers;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Mapping.AccountManagers;
 using Xunit;
 
@@ -22,7 +23,7 @@ public class OwnersResponseToAccountManagersTests
 		UserId = USERID,
 	};
 
-	readonly OwnersResponse responses = new();
+	readonly PaginatedResponse<OwnerResponse> responses = new();
 
 	[Fact]
 	public void ToAccountManagers_ArgResultsNull_ThrowException()

--- a/test/Pelican.Infrastructure.HubSpot.Test/Mapping/Clients/CompaniesResponseToClientsTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Mapping/Clients/CompaniesResponseToClientsTests.cs
@@ -2,6 +2,7 @@
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Domain;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Clients;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Mapping.Clients;
 using Xunit;
 
@@ -23,7 +24,7 @@ public class CompaniesResponseToClientsTests
 		}
 	};
 
-	readonly CompaniesResponse responses = new();
+	readonly PaginatedResponse<CompanyResponse> responses = new();
 
 	[Fact]
 	public async void ToClients_ArgResultsNull_ThrowException()

--- a/test/Pelican.Infrastructure.HubSpot.Test/Mapping/Contacts/ContactsResponseToContactsTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Mapping/Contacts/ContactsResponseToContactsTests.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Domain;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Contacts;
 using Pelican.Infrastructure.HubSpot.Mapping.Contacts;
 using Xunit;
@@ -23,7 +24,7 @@ public class ContactsResponseToContactsTests
 		}
 	};
 
-	readonly ContactsResponse responses = new();
+	readonly PaginatedResponse<ContactResponse> responses = new();
 
 	[Fact]
 	public async Task ToContacts_ArgResultsNull_ThrowExceptionAsync()

--- a/test/Pelican.Infrastructure.HubSpot.Test/Mapping/Deals/DealsResponseToDealsTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Mapping/Deals/DealsResponseToDealsTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Domain;
 using Pelican.Domain.Entities;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Deals;
 using Pelican.Infrastructure.HubSpot.Mapping.Deals;
 using Xunit;
@@ -25,7 +26,7 @@ public class DealsResponseToDealsTests
 
 	private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
 
-	readonly DealsResponse responses = new();
+	readonly PaginatedResponse<DealResponse> responses = new();
 
 	[Fact]
 	public async Task ToDeals_ArgResultsNull_ThrowException()

--- a/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotAccountManagerServicesTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotAccountManagerServicesTests.cs
@@ -5,9 +5,7 @@ using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.AccountManagers;
-using Pelican.Infrastructure.HubSpot.Contracts.Responses.Clients;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
-using Pelican.Infrastructure.HubSpot.Extensions;
 using Pelican.Infrastructure.HubSpot.Services;
 using RestSharp;
 using Xunit;
@@ -131,7 +129,7 @@ public class HubSpotAccountManagerServicesTests
 		/// Arrange
 		Mock<IResponse<PaginatedResponse<OwnerResponse>>> responseMock = new();
 
-		List<AccountManager> deals = new();
+		List<AccountManager> accountManagers = new();
 
 		_hubSpotClientMock
 			.Setup(client => client.GetAsync<PaginatedResponse<OwnerResponse>>(
@@ -141,7 +139,7 @@ public class HubSpotAccountManagerServicesTests
 
 		responseMock
 			.Setup(r => r.GetResult(It.IsAny<Func<PaginatedResponse<OwnerResponse>, List<AccountManager>>>()))
-			.Returns(deals);
+			.Returns(accountManagers);
 
 		/// Act
 		var result = await _uut.GetAsync("", default);
@@ -149,7 +147,7 @@ public class HubSpotAccountManagerServicesTests
 		/// Assert
 		Assert.True(result.IsSuccess);
 		Assert.Equal(
-			deals,
+			accountManagers,
 			result.Value);
 	}
 
@@ -160,7 +158,7 @@ public class HubSpotAccountManagerServicesTests
 		Mock<IResponse<PaginatedResponse<OwnerResponse>>> responseMock0 = new();
 		Mock<IResponse<PaginatedResponse<OwnerResponse>>> responseMock1 = new();
 
-		List<AccountManager> deals = new();
+		List<AccountManager> accountManagers = new();
 
 		Paging p = new()
 		{
@@ -186,11 +184,11 @@ public class HubSpotAccountManagerServicesTests
 
 		responseMock0
 			.Setup(r => r.GetResult(It.IsAny<Func<PaginatedResponse<OwnerResponse>, List<AccountManager>>>()))
-			.Returns(deals);
+			.Returns(accountManagers);
 
 		responseMock1
 			.Setup(r => r.GetResult(It.IsAny<Func<PaginatedResponse<OwnerResponse>, List<AccountManager>>>()))
-			.Returns(deals);
+			.Returns(accountManagers);
 
 		/// Act
 		var result = await _uut.GetAsync("", default);
@@ -198,7 +196,7 @@ public class HubSpotAccountManagerServicesTests
 		/// Assert
 		Assert.True(result.IsSuccess);
 		Assert.Equal(
-			deals,
+			accountManagers,
 			result.Value);
 	}
 }

--- a/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotClientServicesTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotClientServicesTests.cs
@@ -5,6 +5,7 @@ using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Clients;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Services;
 using RestSharp;
 using Xunit;
@@ -108,17 +109,17 @@ public class HubSpotClientServicesTests
 	public async Task GetAsync_ClientReturnsFailure_ReturnFailure()
 	{
 		/// Arrange
-		Mock<IResponse<CompaniesResponse>> responseMock = new();
+		Mock<IResponse<PaginatedResponse<CompanyResponse>>> responseMock = new();
 
 		_hubSpotClientMock
-			.Setup(client => client.GetAsync<CompaniesResponse>(
+			.Setup(client => client.GetAsync<PaginatedResponse<CompanyResponse>>(
 				It.IsAny<RestRequest>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(responseMock.Object);
 
 		responseMock
 			.Setup(r => r.GetResultWithUnitOfWork(
-				It.IsAny<Func<CompaniesResponse, IUnitOfWork, CancellationToken, Task<List<Client>>>>(),
+				It.IsAny<Func<PaginatedResponse<CompanyResponse>, IUnitOfWork, CancellationToken, Task<List<Client>>>>(),
 				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Failure<List<Client>>(Error.NullValue));
@@ -134,12 +135,12 @@ public class HubSpotClientServicesTests
 	public async Task GetAsync_ClientReturnsSuccess_ReturnSuccess()
 	{
 		/// Arrange
-		Mock<IResponse<CompaniesResponse>> responseMock = new();
+		Mock<IResponse<PaginatedResponse<CompanyResponse>>> responseMock = new();
 
 		List<Client> Clients = new();
 
 		_hubSpotClientMock
-			.Setup(client => client.GetAsync<CompaniesResponse>(
+			.Setup(client => client.GetAsync<PaginatedResponse<CompanyResponse>>(
 				It.IsAny<RestRequest>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(responseMock.Object);
@@ -147,7 +148,7 @@ public class HubSpotClientServicesTests
 
 		responseMock
 			.Setup(r => r.GetResultWithUnitOfWork(
-				It.IsAny<Func<CompaniesResponse, IUnitOfWork, CancellationToken, Task<List<Client>>>>(),
+				It.IsAny<Func<PaginatedResponse<CompanyResponse>, IUnitOfWork, CancellationToken, Task<List<Client>>>>(),
 				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(Clients));

--- a/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotContactServicesTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotContactServicesTests.cs
@@ -4,6 +4,7 @@ using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Contacts;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Deals;
 using Pelican.Infrastructure.HubSpot.Services;
@@ -112,17 +113,17 @@ public class HubSpotContactServicesTests
 	public async Task GetAsync_ClientReturnsFailure_ReturnFailure()
 	{
 		/// Arrange
-		Mock<IResponse<ContactsResponse>> responseMock = new();
+		Mock<IResponse<PaginatedResponse<ContactResponse>>> responseMock = new();
 
 		_hubSpotClientMock
-			.Setup(client => client.GetAsync<ContactsResponse>(
+			.Setup(client => client.GetAsync<PaginatedResponse<ContactResponse>>(
 				It.IsAny<RestRequest>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(responseMock.Object);
 
 		responseMock
 			.Setup(r => r.GetResultWithUnitOfWork(
-				It.IsAny<Func<ContactsResponse, IUnitOfWork, CancellationToken, Task<List<Contact>>>>(),
+				It.IsAny<Func<PaginatedResponse<ContactResponse>, IUnitOfWork, CancellationToken, Task<List<Contact>>>>(),
 				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Failure<List<Contact>>(Error.NullValue));
@@ -138,19 +139,19 @@ public class HubSpotContactServicesTests
 	public async Task GetAsync_ClientReturnsSuccess_ReturnSuccess()
 	{
 		/// Arrange
-		Mock<IResponse<ContactsResponse>> responseMock = new();
+		Mock<IResponse<PaginatedResponse<ContactResponse>>> responseMock = new();
 
 		List<Contact> Contacts = new();
 
 		_hubSpotClientMock
-			.Setup(client => client.GetAsync<ContactsResponse>(
+			.Setup(client => client.GetAsync<PaginatedResponse<ContactResponse>>(
 				It.IsAny<RestRequest>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(responseMock.Object);
 
 		responseMock
 			.Setup(r => r.GetResultWithUnitOfWork(
-				It.IsAny<Func<ContactsResponse, IUnitOfWork, CancellationToken, Task<List<Contact>>>>(),
+				It.IsAny<Func<PaginatedResponse<ContactResponse>, IUnitOfWork, CancellationToken, Task<List<Contact>>>>(),
 				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Contacts);

--- a/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotDealServicesTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotDealServicesTests.cs
@@ -4,6 +4,7 @@ using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Deals;
 using Pelican.Infrastructure.HubSpot.Services;
 using RestSharp;
@@ -114,17 +115,17 @@ public class HubSpotDealServicesTests
 	public async Task GetAsync_ClientReturnsFailure_ReturnFailure()
 	{
 		/// Arrange
-		Mock<IResponse<DealsResponse>> responseMock = new();
+		Mock<IResponse<PaginatedResponse<DealResponse>>> responseMock = new();
 
 		_hubSpotClientMock
-			.Setup(client => client.GetAsync<DealsResponse>(
+			.Setup(client => client.GetAsync<PaginatedResponse<DealResponse>>(
 				It.IsAny<RestRequest>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(responseMock.Object);
 
 		responseMock
 			.Setup(r => r.GetResultWithUnitOfWork(
-				It.IsAny<Func<DealsResponse, IUnitOfWork, CancellationToken, Task<List<Deal>>>>(),
+				It.IsAny<Func<PaginatedResponse<DealResponse>, IUnitOfWork, CancellationToken, Task<List<Deal>>>>(),
 				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Failure<List<Deal>>(Error.NullValue));
@@ -140,19 +141,19 @@ public class HubSpotDealServicesTests
 	public async Task GetAsync_ClientReturnsSuccess_ReturnSuccess()
 	{
 		/// Arrange
-		Mock<IResponse<DealsResponse>> responseMock = new();
+		Mock<IResponse<PaginatedResponse<DealResponse>>> responseMock = new();
 
 		List<Deal> deals = new();
 
 		_hubSpotClientMock
-			.Setup(client => client.GetAsync<DealsResponse>(
+			.Setup(client => client.GetAsync<PaginatedResponse<DealResponse>>(
 				It.IsAny<RestRequest>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(responseMock.Object);
 
 		responseMock
 			.Setup(r => r.GetResultWithUnitOfWork(
-				It.IsAny<Func<DealsResponse, IUnitOfWork, CancellationToken, Task<List<Deal>>>>(),
+				It.IsAny<Func<PaginatedResponse<DealResponse>, IUnitOfWork, CancellationToken, Task<List<Deal>>>>(),
 				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(deals));

--- a/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotDealServicesTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Services/HubSpotDealServicesTests.cs
@@ -4,6 +4,7 @@ using Pelican.Application.Abstractions.Infrastructure;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Settings.HubSpot;
 using Pelican.Domain.Shared;
+using Pelican.Infrastructure.HubSpot.Contracts.Responses.Clients;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Common;
 using Pelican.Infrastructure.HubSpot.Contracts.Responses.Deals;
 using Pelican.Infrastructure.HubSpot.Services;
@@ -14,9 +15,6 @@ namespace Pelican.Infrastructure.HubSpot.Test.Services;
 
 public class HubSpotDealServicesTests
 {
-	private const string ID = "Id";
-	private const string OWNERID = "OwnerId";
-
 	private readonly Mock<IClient<HubSpotSettings>> _hubSpotClientMock = new();
 	private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
 	private readonly HubSpotDealService _uut;
@@ -157,6 +155,61 @@ public class HubSpotDealServicesTests
 				It.IsAny<IUnitOfWork>(),
 				It.IsAny<CancellationToken>()))
 			.ReturnsAsync(Result.Success(deals));
+
+		/// Act
+		var result = await _uut.GetAsync("", default);
+
+		/// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(
+			deals,
+			result.Value);
+	}
+
+	[Fact]
+	public async Task GetAsync_ClientReturnsSuccessTwice_ReturnSuccess()
+	{
+		/// Arrange
+		Mock<IResponse<PaginatedResponse<DealResponse>>> responseMock0 = new();
+		Mock<IResponse<PaginatedResponse<DealResponse>>> responseMock1 = new();
+
+		List<Deal> deals = new();
+
+		Paging p = new()
+		{
+			Next = new()
+			{
+				After = "1",
+			}
+		};
+
+		responseMock0
+			.Setup(r => r.Data)
+			.Returns(new PaginatedResponse<DealResponse>()
+			{
+				Paging = p,
+			});
+
+		_hubSpotClientMock
+			.SetupSequence(client => client.GetAsync<PaginatedResponse<DealResponse>>(
+				It.IsAny<RestRequest>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(responseMock0.Object)
+			.ReturnsAsync(responseMock1.Object);
+
+		responseMock0
+			.Setup(r => r.GetResultWithUnitOfWork(
+				It.IsAny<Func<PaginatedResponse<DealResponse>, IUnitOfWork, CancellationToken, Task<List<Deal>>>>(),
+				It.IsAny<IUnitOfWork>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(deals);
+
+		responseMock1
+			.Setup(r => r.GetResultWithUnitOfWork(
+				It.IsAny<Func<PaginatedResponse<DealResponse>, IUnitOfWork, CancellationToken, Task<List<Deal>>>>(),
+				It.IsAny<IUnitOfWork>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(deals);
 
 		/// Act
 		var result = await _uut.GetAsync("", default);


### PR DESCRIPTION
For at sikre at alt data hentes fra hubspot, hvis der skulle være flere sider er følgende lavet. 
I stedet for at have forskellige responstyper for lister af client, deals og så videre er der lavet en generisk klasse `PaginatedResponse`, da det gjorde det lette at genbruge logikken for at tjekke om der er flere sider. 
Dermed er en del af ændringerne at bruge denne type i stedet for de gamle.

Herefter er `IResponse` udvidet, så man kan hente propertien `After` hvis typen af `IResponse` er`IResponse<PaginatedResponse>`.

Efter disse ændringer er hubspot services opdateret, så hubspot kaldes flere gange hvis der er flere sider.