### PR TITLE
Feature/plcn 350 create create admin command handler

### DIFF
--- a/src/Pelican.Application/Authentication/CreateAdmin/CreateAdminCommandHandler.cs
+++ b/src/Pelican.Application/Authentication/CreateAdmin/CreateAdminCommandHandler.cs
@@ -1,0 +1,34 @@
+﻿using Pelican.Application.Abstractions.Authentication;
+using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.Abstractions.Messaging;
+using Pelican.Domain.Entities.Users;
+using Pelican.Domain.Shared;
+
+namespace Pelican.Application.Authentication.CreateAdmin;
+public class CreateAdminCommandHandler : ICommandHandler<CreateAdminCommand>
+{
+	private readonly IUnitOfWork _unitOfWork;
+	private readonly IPasswordHasher _passwordHasher;
+
+	public CreateAdminCommandHandler(
+		IUnitOfWork unitOfWork,
+		IPasswordHasher passwordHasher)
+	{
+		_unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+		_passwordHasher = passwordHasher ?? throw new ArgumentNullException(nameof(passwordHasher));
+	}
+	public async Task<Result> Handle(CreateAdminCommand request, CancellationToken cancellationToken)
+	{
+		var userEntity = new AdminUser
+		{
+			Email = request.Email,
+			Password = _passwordHasher.Hash(request.Password),
+			Name = request.Name,
+		};
+
+		await _unitOfWork.UserRepository.CreateAsync(userEntity);
+		await _unitOfWork.SaveAsync(cancellationToken);
+
+		return Result.Success();
+	}
+}

--- a/src/Pelican.Application/Authentication/CreateAdmin/CreateAdminCommandHandler.cs
+++ b/src/Pelican.Application/Authentication/CreateAdmin/CreateAdminCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Pelican.Application.Abstractions.Authentication;
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.Messaging;
+using Pelican.Application.Users.Commands.CreateAdmin;
 using Pelican.Domain.Entities.Users;
 using Pelican.Domain.Shared;
 

--- a/src/Pelican.Application/Users/Commands/CreateAdmin/CreateAdminCommand.cs
+++ b/src/Pelican.Application/Users/Commands/CreateAdmin/CreateAdminCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Pelican.Application.Abstractions.Messaging;
+using Pelican.Domain.Entities;
 
 namespace Pelican.Application.Users.Commands.CreateAdmin;
-public sealed record CreateAdminCommand(string Name, string Email, string Password) : ICommand;
+public sealed record CreateAdminCommand(string Name, string Email, string Password) : ICommand<User>;

--- a/src/Pelican.Application/Users/Commands/CreateAdmin/CreateAdminCommandHandler.cs
+++ b/src/Pelican.Application/Users/Commands/CreateAdmin/CreateAdminCommandHandler.cs
@@ -1,12 +1,12 @@
 ﻿using Pelican.Application.Abstractions.Authentication;
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.Messaging;
-using Pelican.Application.Users.Commands.CreateAdmin;
+using Pelican.Domain.Entities;
 using Pelican.Domain.Entities.Users;
 using Pelican.Domain.Shared;
 
-namespace Pelican.Application.Authentication.CreateAdmin;
-public class CreateAdminCommandHandler : ICommandHandler<CreateAdminCommand>
+namespace Pelican.Application.Users.Commands.CreateAdmin;
+public class CreateAdminCommandHandler : ICommandHandler<CreateAdminCommand, User>
 {
 	private readonly IUnitOfWork _unitOfWork;
 	private readonly IPasswordHasher _passwordHasher;
@@ -18,9 +18,14 @@ public class CreateAdminCommandHandler : ICommandHandler<CreateAdminCommand>
 		_unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
 		_passwordHasher = passwordHasher ?? throw new ArgumentNullException(nameof(passwordHasher));
 	}
-	public async Task<Result> Handle(CreateAdminCommand request, CancellationToken cancellationToken)
+	public async Task<Result<User>> Handle(CreateAdminCommand request, CancellationToken cancellationToken)
 	{
-		var userEntity = new AdminUser
+		if (await _unitOfWork.UserRepository.AnyAsync(x => x.Email == request.Email, cancellationToken))
+		{
+			return Result.Failure<User>(Error.AlreadyExists);
+		}
+
+		User userEntity = new AdminUser
 		{
 			Email = request.Email,
 			Password = _passwordHasher.Hash(request.Password),
@@ -30,6 +35,6 @@ public class CreateAdminCommandHandler : ICommandHandler<CreateAdminCommand>
 		await _unitOfWork.UserRepository.CreateAsync(userEntity);
 		await _unitOfWork.SaveAsync(cancellationToken);
 
-		return Result.Success();
+		return Result.Success(userEntity);
 	}
 }

--- a/test/Pelican.Application.Test/CreateAdmin/Commands/CreateAdminCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/CreateAdmin/Commands/CreateAdminCommandHandlerTests.cs
@@ -53,7 +53,7 @@ public class CreateAdminCommandHandlerTests
 	public async void Handle_UserRepositoryAnyAsyncReturnsTrue_ReturnsFailure()
 	{
 		//Arrange
-		CreateAdminCommand createAdminCommand = new("test", "test", "test");
+		CreateAdminCommand createAdminCommand = new("testName", "testEmail", "testPassword");
 
 		_unitOfWorkMock
 			.Setup(x => x
@@ -65,9 +65,9 @@ public class CreateAdminCommandHandlerTests
 
 		AdminUser expectedUser = new()
 		{
-			Name = "test",
+			Name = "testName",
 			Password = "HashedPW",
-			Email = "test",
+			Email = "testEmail",
 		};
 
 		//Act
@@ -79,7 +79,8 @@ public class CreateAdminCommandHandlerTests
 				.UserRepository
 				.AnyAsync(x => x
 					.Email == createAdminCommand.Email,
-					default));
+					default),
+			Times.Once);
 
 		Assert.True(result.IsFailure);
 	}
@@ -88,7 +89,7 @@ public class CreateAdminCommandHandlerTests
 	public async void Handle_UserRepositoryAnyAsyncReturnsFalseSaveIsCalledCreateAsyncIsCalledWithExpectedUserPassWordHasherIsCalledWithExpectedPassword_ReturnsSuccess()
 	{
 		//Arrange
-		CreateAdminCommand createAdminCommand = new("test", "test", "test");
+		CreateAdminCommand createAdminCommand = new("testName", "testEmail", "testPassword");
 
 		_passwordHasherMock.Setup(x => x.Hash(It.IsAny<string>())).Returns("HashedPW");
 
@@ -104,9 +105,9 @@ public class CreateAdminCommandHandlerTests
 
 		AdminUser expectedUser = new()
 		{
-			Name = "test",
+			Name = "testName",
 			Password = "HashedPW",
-			Email = "test",
+			Email = "testEmail",
 		};
 
 		//Act
@@ -118,18 +119,24 @@ public class CreateAdminCommandHandlerTests
 				.UserRepository
 				.AnyAsync(x => x
 					.Email == createAdminCommand.Email,
-					default));
+					default),
+			Times.Once);
 
 		_unitOfWorkMock
 			.Verify(x => x
 				.UserRepository
-				.CreateAsync(expectedUser, default), Times.Once);
+				.CreateAsync(expectedUser, default),
+			Times.Once);
 
 		_unitOfWorkMock
 			.Verify(x => x
-				.SaveAsync(default), Times.Once);
+				.SaveAsync(default),
+			Times.Once);
 
-		_passwordHasherMock.Verify(x => x.Hash("test"));
+		_passwordHasherMock
+			.Verify(x => x
+				.Hash("testPassword"),
+			Times.Once);
 
 		Assert.True(result.IsSuccess);
 

--- a/test/Pelican.Application.Test/CreateAdmin/Commands/CreateAdminCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/CreateAdmin/Commands/CreateAdminCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Pelican.Application.Abstractions.Authentication;
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Abstractions.Messaging;
 using Pelican.Application.Authentication.CreateAdmin;
+using Pelican.Application.Users.Commands.CreateAdmin;
 using Pelican.Domain.Entities;
 using Pelican.Domain.Entities.Users;
 using Xunit;

--- a/test/Pelican.Application.Test/CreateAdmin/Commands/CreateAdminCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/CreateAdmin/Commands/CreateAdminCommandHandlerTests.cs
@@ -54,7 +54,7 @@ public class CreateAdminCommandHandlerTests
 	}
 
 	[Fact]
-	public async void Handler()
+	public async void Handle_SaveIsCalledCreateAsyncIsCalledWithExpectedUserPassWordHasherIsCalledWithExpectedPassword_ReturnsSuccess()
 	{
 		//Arrange
 		CreateAdminCommand createAdminCommand = new("test", "test", "test");

--- a/test/Pelican.Application.Test/CreateAdmin/Commands/CreateAdminCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/CreateAdmin/Commands/CreateAdminCommandHandlerTests.cs
@@ -1,0 +1,84 @@
+﻿using Moq;
+using Pelican.Application.Abstractions.Authentication;
+using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.Abstractions.Messaging;
+using Pelican.Application.Authentication.CreateAdmin;
+using Pelican.Domain.Entities;
+using Pelican.Domain.Entities.Users;
+using Xunit;
+
+namespace Pelican.Application.Test.CreateAdmin.Commands;
+public class CreateAdminCommandHandlerTests
+{
+	private readonly ICommandHandler<CreateAdminCommand> _uut;
+	private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+	private readonly Mock<IPasswordHasher> _passwordHasherMock = new();
+
+	public CreateAdminCommandHandlerTests()
+	{
+		_uut = new CreateAdminCommandHandler(_unitOfWorkMock.Object, _passwordHasherMock.Object);
+	}
+
+	[Fact]
+	public void Constructor_UnitOfWorkNull_ArgumentNullException()
+	{
+		//Arrange
+
+		//Act
+		var result = Record.Exception(() => new CreateAdminCommandHandler(null!, _passwordHasherMock.Object));
+
+		//Assert
+		Assert.IsType<ArgumentNullException>(result);
+
+		Assert.Contains(
+			"unitOfWork",
+			result.Message);
+	}
+
+	[Fact]
+	public void Constructor_PassWordHasherNull_ArgumentNullException()
+	{
+		//Arrange
+
+		//Act
+		var result = Record.Exception(() => new CreateAdminCommandHandler(_unitOfWorkMock.Object, null!));
+
+		//Assert
+		Assert.IsType<ArgumentNullException>(result);
+
+		Assert.Contains(
+			"passwordHasher",
+			result.Message);
+
+	}
+
+	[Fact]
+	public async void Handler()
+	{
+		//Arrange
+		CreateAdminCommand createAdminCommand = new("test", "test", "test");
+
+		_passwordHasherMock.Setup(x => x.Hash(It.IsAny<string>())).Returns("HashedPW");
+
+		_unitOfWorkMock.Setup(x => x.UserRepository.CreateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()));
+
+		AdminUser expectedUser = new()
+		{
+			Name = "test",
+			Password = "HashedPW",
+			Email = "test",
+		};
+
+		//Act
+		var result = await _uut.Handle(createAdminCommand, default);
+
+		//Assert
+		_unitOfWorkMock.Verify(x => x.UserRepository.CreateAsync(expectedUser, default), Times.Once);
+
+		_unitOfWorkMock.Verify(x => x.SaveAsync(default), Times.Once);
+
+		_passwordHasherMock.Verify(x => x.Hash("test"));
+
+		Assert.True(result.IsSuccess);
+	}
+}


### PR DESCRIPTION
Created a commandhandler for CreateAdminCommand, the Admin is created from the request, but the password is hashed first to encrypt it. Tests have also been implemented