### PR TITLE
 Feature/plcn 373 create update password command handler

### DIFF
--- a/src/Pelican.Application/Users/Commands/UpdatePassword/UpdatePasswordCommandHandler.cs
+++ b/src/Pelican.Application/Users/Commands/UpdatePassword/UpdatePasswordCommandHandler.cs
@@ -18,9 +18,9 @@ public sealed class UpdatePasswordCommandHandler : ICommandHandler<UpdatePasswor
 		ICurrentUserService currentUserService,
 		IPasswordHasher passwordHasher)
 	{
-		_unitOfWork = unitOfWork;
-		_currentUserService = currentUserService;
-		_passwordHasher = passwordHasher;
+		_unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+		_currentUserService = currentUserService ?? throw new ArgumentNullException(nameof(currentUserService));
+		_passwordHasher = passwordHasher ?? throw new ArgumentNullException(nameof(passwordHasher));
 	}
 
 	public async Task<Result<User>> Handle(

--- a/src/Pelican.Application/Users/Commands/UpdatePassword/UpdatePasswordCommandHandler.cs
+++ b/src/Pelican.Application/Users/Commands/UpdatePassword/UpdatePasswordCommandHandler.cs
@@ -1,0 +1,51 @@
+
+using Pelican.Application.Abstractions.Authentication;
+using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.Abstractions.Messaging;
+using Pelican.Domain.Entities;
+using Pelican.Domain.Shared;
+
+namespace Pelican.Application.Users.Commands.UpdatePassword;
+
+public sealed class UpdatePasswordCommandHandler : ICommandHandler<UpdatePasswordCommand, User>
+{
+	private readonly IUnitOfWork _unitOfWork;
+	private readonly ICurrentUserService _currentUserService;
+	private readonly IPasswordHasher _passwordHasher;
+
+	public UpdatePasswordCommandHandler(
+		IUnitOfWork unitOfWork,
+		ICurrentUserService currentUserService,
+		IPasswordHasher passwordHasher)
+	{
+		_unitOfWork = unitOfWork;
+		_currentUserService = currentUserService;
+		_passwordHasher = passwordHasher;
+	}
+
+	public async Task<Result<User>> Handle(
+		UpdatePasswordCommand command,
+		CancellationToken cancellationToken)
+	{
+		User? user = await _unitOfWork
+			.UserRepository
+			.FirstOrDefaultAsync(
+				x => x.Email == _currentUserService.UserId,
+				cancellationToken);
+
+		if (user is null)
+		{
+			return Result.Failure<User>(new Error("User.NotFound", $"{_currentUserService.UserId} was not found"));
+		}
+
+		user.Password = _passwordHasher.Hash(command.Password);
+
+		_unitOfWork
+			.UserRepository
+			.Update(user);
+
+		await _unitOfWork.SaveAsync(cancellationToken);
+
+		return user;
+	}
+}

--- a/src/Pelican.Application/Users/Commands/UpdatePassword/UpdatePasswordCommandHandler.cs
+++ b/src/Pelican.Application/Users/Commands/UpdatePassword/UpdatePasswordCommandHandler.cs
@@ -27,15 +27,17 @@ public sealed class UpdatePasswordCommandHandler : ICommandHandler<UpdatePasswor
 		UpdatePasswordCommand command,
 		CancellationToken cancellationToken)
 	{
+		string? userId = _currentUserService.UserId;
+
 		User? user = await _unitOfWork
 			.UserRepository
 			.FirstOrDefaultAsync(
-				x => x.Email == _currentUserService.UserId,
+			 	x => x.Email == userId,
 				cancellationToken);
 
 		if (user is null)
 		{
-			return Result.Failure<User>(new Error("User.NotFound", $"{_currentUserService.UserId} was not found"));
+			return Result.Failure<User>(new Error("User.NotFound", $"{userId} was not found"));
 		}
 
 		user.Password = _passwordHasher.Hash(command.Password);

--- a/test/Pelican.Application.Test/Users/Commands/UpdatePassword/UpdatePasswordCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Users/Commands/UpdatePassword/UpdatePasswordCommandHandlerTests.cs
@@ -26,6 +26,66 @@ public class UpdatePasswordCommandHandlerTests
 	}
 
 	[Fact]
+	public void UpdatePasswordCommandHandler_UnitOfWorkNull_ThrowException()
+	{
+		/// Act
+		Exception exceptionResult = Record.Exception(() =>
+			new UpdatePasswordCommandHandler(
+				null!,
+				_currentUserServiceMock.Object,
+				_passwordHasherMock.Object));
+
+		/// Assert
+		Assert.Equal(
+			typeof(ArgumentNullException),
+			exceptionResult.GetType());
+
+		Assert.Equal(
+			"Value cannot be null. (Parameter 'unitOfWork')",
+			exceptionResult.Message);
+	}
+
+	[Fact]
+	public void UpdatePasswordCommandHandler_CurrentUserServiceNull_ThrowException()
+	{
+		/// Act
+		Exception exceptionResult = Record.Exception(() =>
+			new UpdatePasswordCommandHandler(
+				_unitOfWorkMock.Object,
+				null!,
+				_passwordHasherMock.Object));
+
+		/// Assert
+		Assert.Equal(
+			typeof(ArgumentNullException),
+			exceptionResult.GetType());
+
+		Assert.Equal(
+			"Value cannot be null. (Parameter 'currentUserService')",
+			exceptionResult.Message);
+	}
+
+	[Fact]
+	public void UpdatePasswordCommandHandler_PasswordHasherNull_ThrowException()
+	{
+		/// Act
+		Exception exceptionResult = Record.Exception(() =>
+			new UpdatePasswordCommandHandler(
+				_unitOfWorkMock.Object,
+				_currentUserServiceMock.Object,
+				null!));
+
+		/// Assert
+		Assert.Equal(
+			typeof(ArgumentNullException),
+			exceptionResult.GetType());
+
+		Assert.Equal(
+			"Value cannot be null. (Parameter 'passwordHasher')",
+			exceptionResult.Message);
+	}
+
+	[Fact]
 	public async void Handle_UserNotFound_ReturnsFailure()
 	{
 		// Arrange

--- a/test/Pelican.Application.Test/Users/Commands/UpdatePassword/UpdatePasswordCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Users/Commands/UpdatePassword/UpdatePasswordCommandHandlerTests.cs
@@ -1,0 +1,84 @@
+using System.Linq.Expressions;
+using Moq;
+using Pelican.Application.Abstractions.Authentication;
+using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.Users.Commands.UpdatePassword;
+using Pelican.Domain.Entities;
+using Pelican.Domain.Shared;
+using Xunit;
+
+namespace Pelican.Application.Test.Users.Commands.UpdatePassword;
+
+public class UpdatePasswordCommandHandlerTests
+{
+	private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+	private readonly Mock<ICurrentUserService> _currentUserServiceMock = new();
+	private readonly Mock<IPasswordHasher> _passwordHasherMock = new();
+	private readonly UpdatePasswordCommandHandler _uut;
+
+	public UpdatePasswordCommandHandlerTests()
+	{
+		_uut = new(
+			_unitOfWorkMock.Object,
+			_currentUserServiceMock.Object,
+			_passwordHasherMock.Object);
+	}
+
+	[Fact]
+	public async void Handle_UserNotFound_ReturnsFailure()
+	{
+		// Arrange
+		UpdatePasswordCommand command = new("password");
+
+		_unitOfWorkMock
+			.Setup(u => u
+				.UserRepository
+				.FirstOrDefaultAsync(
+					It.IsAny<Expression<Func<User, bool>>>(),
+					It.IsAny<CancellationToken>()))
+			.ReturnsAsync((User)null!);
+
+		_currentUserServiceMock
+			.Setup(c => c.UserId)
+			.Returns("id");
+
+		// Act
+		var result = await _uut.Handle(command, default);
+
+		// Assert
+		Assert.True(result.IsFailure);
+
+		Assert.Equal(
+			new Error("User.NotFound", "id was not found"),
+			result.Error);
+	}
+
+	[Fact]
+	public async void Handle_UserFoundAndUpdated_ReturnsSuccess()
+	{
+		// Arrange
+		UpdatePasswordCommand command = new("password");
+
+		_unitOfWorkMock
+			.Setup(u => u
+				.UserRepository
+				.FirstOrDefaultAsync(
+					It.IsAny<Expression<Func<User, bool>>>(),
+					It.IsAny<CancellationToken>()))
+			.ReturnsAsync((User)null!);
+
+		_currentUserServiceMock
+			.Setup(c => c.UserId)
+			.Returns("id");
+
+		_passwordHasherMock
+			.Setup(p => p.Hash(It.IsAny<string>()))
+			.Returns("hashedPassword");
+
+		// Act
+		var result = await _uut.Handle(command, default);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+	}
+}

--- a/test/Pelican.Application.Test/Users/Commands/UpdatePassword/UpdatePasswordCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Users/Commands/UpdatePassword/UpdatePasswordCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Pelican.Application.Abstractions.Authentication;
 using Pelican.Application.Abstractions.Data.Repositories;
 using Pelican.Application.Users.Commands.UpdatePassword;
 using Pelican.Domain.Entities;
+using Pelican.Domain.Entities.Users;
 using Pelican.Domain.Shared;
 using Xunit;
 
@@ -65,7 +66,7 @@ public class UpdatePasswordCommandHandlerTests
 				.FirstOrDefaultAsync(
 					It.IsAny<Expression<Func<User, bool>>>(),
 					It.IsAny<CancellationToken>()))
-			.ReturnsAsync((User)null!);
+			.ReturnsAsync(new StandardUser());
 
 		_currentUserServiceMock
 			.Setup(c => c.UserId)


### PR DESCRIPTION
Added handler to update a users password. Returns error if user is not found. If found password will be updated