### PR TITLE
Feature/plcn 360 create update user command handler

### DIFF
--- a/src/Pelican.Application/Users/Commands/UpdateUser/UpdateUserCommandHandler.cs
+++ b/src/Pelican.Application/Users/Commands/UpdateUser/UpdateUserCommandHandler.cs
@@ -1,0 +1,52 @@
+using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.Abstractions.Messaging;
+using Pelican.Domain.Entities;
+using Pelican.Domain.Shared;
+
+namespace Pelican.Application.Users.Commands.UpdateUser;
+
+public sealed class UpdateUserCommandHandler : ICommandHandler<UpdateUserCommand, User>
+{
+	private readonly IUnitOfWork _unitOfWork;
+
+	public UpdateUserCommandHandler(IUnitOfWork unitOfWork)
+	{
+		_unitOfWork = unitOfWork;
+	}
+
+	public async Task<Result<User>> Handle(
+		UpdateUserCommand command,
+		CancellationToken cancellationToken)
+	{
+		User? user = await _unitOfWork
+			.UserRepository
+			.FirstOrDefaultAsync(
+				u => u.Id == command.User.Id,
+				cancellationToken);
+
+		if (user is null)
+		{
+			return Result.Failure<User>(new Error("User.NotFound", $"{command.User.Id} was not found"));
+		}
+
+		if (command.User.Email is not null && await _unitOfWork
+				.UserRepository
+				.AnyAsync(
+					x => x.Email == command.User.Email,
+					cancellationToken))
+		{
+			return Result.Failure<User>(new Error("Email.InUse", "Email already in use"));
+		}
+
+		user.Name = command.User.Name ?? user.Name;
+		user.Email = command.User.Email ?? user.Email;
+
+		_unitOfWork
+			.UserRepository
+			.Update(user);
+
+		await _unitOfWork.SaveAsync(cancellationToken);
+
+		return user;
+	}
+}

--- a/src/Pelican.Application/Users/Commands/UpdateUser/UpdateUserCommandHandler.cs
+++ b/src/Pelican.Application/Users/Commands/UpdateUser/UpdateUserCommandHandler.cs
@@ -11,7 +11,7 @@ public sealed class UpdateUserCommandHandler : ICommandHandler<UpdateUserCommand
 
 	public UpdateUserCommandHandler(IUnitOfWork unitOfWork)
 	{
-		_unitOfWork = unitOfWork ?? throw new ArgumentNullException(paramName: nameof(unitOfWork));
+		_unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
 	}
 
 	public async Task<Result<User>> Handle(
@@ -21,35 +21,35 @@ public sealed class UpdateUserCommandHandler : ICommandHandler<UpdateUserCommand
 		User? user = await _unitOfWork
 			.UserRepository
 			.FirstOrDefaultAsync(
-				expression: u => u.Id == command.User.Id,
-				cancellationToken: cancellationToken);
+				u => u.Id == command.User.Id,
+				cancellationToken);
 
 		if (user is null)
 		{
 			return new Error(
-				code: "User.NotFound",
-				message: $"{command.User.Id} was not found");
+				"User.NotFound",
+				$"User with Id: {command.User.Id} was not found");
 		}
 
-		if (command.User.Email is not null && await _unitOfWork
+		if (await _unitOfWork
 				.UserRepository
 				.AnyAsync(
-					expression: x => x.Email == command.User.Email,
-					cancellationToken: cancellationToken))
+					x => x.Email == command.User.Email,
+					cancellationToken))
 		{
 			return new Error(
-				code: "Email.InUse",
-				message: "Email already in use");
+				"Email.InUse",
+				"Email already in use");
 		}
 
-		user.Name = command.User.Name ?? user.Name;
-		user.Email = command.User.Email ?? user.Email;
+		user.Name = command.User.Name;
+		user.Email = command.User.Email;
 
 		_unitOfWork
 			.UserRepository
-			.Update(entity: user);
+			.Update(user);
 
-		await _unitOfWork.SaveAsync(cancellationToken: cancellationToken);
+		await _unitOfWork.SaveAsync(cancellationToken);
 
 		return user;
 	}

--- a/src/Pelican.Domain/Shared/ResultT.cs
+++ b/src/Pelican.Domain/Shared/ResultT.cs
@@ -13,4 +13,6 @@ public class Result<TValue> : Result
 		: throw new InvalidOperationException("The value of a failure result can not be accessed");
 
 	public static implicit operator Result<TValue>(TValue value) => Success(value);
+
+	public static implicit operator Result<TValue>(Error error) => Failure<TValue>(error);
 }

--- a/test/Pelican.Application.Test/Users/Commands/UpdateUser/UpdateUserCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Users/Commands/UpdateUser/UpdateUserCommandHandlerTests.cs
@@ -58,16 +58,18 @@ public class UpdateUserCommandHandlerTests
 		Assert.True(result.IsFailure);
 
 		Assert.Equal(
-			new Error("User.NotFound", $"{command.User.Id} was not found"),
+			new Error(
+				"User.NotFound",
+				$"User with Id: {command.User.Id} was not found"),
 			result.Error);
 
 		_unitOfWork.Verify(
-			expression: x => x
+			x => x
 				.UserRepository
 				.FirstOrDefaultAsync(
 					u => u.Id == command.User.Id,
 					default),
-			times: Times.Once);
+			Times.Once);
 	}
 
 	[Fact]
@@ -106,24 +108,24 @@ public class UpdateUserCommandHandlerTests
 			result.Error);
 
 		_unitOfWork.Verify(
-			expression: x => x
+			x => x
 				.UserRepository
 				.FirstOrDefaultAsync(
 					u => u.Id == command.User.Id,
 					default),
-			times: Times.Once);
+			Times.Once);
 
 		_unitOfWork.Verify(
-			expression: x => x
+			x => x
 				.UserRepository
 				.AnyAsync(
 					u => u.Email == command.User.Email,
 					default),
-			times: Times.Once);
+			Times.Once);
 	}
 
 	[Fact]
-	public async void Handle_UserUpdated_ReturnFailure()
+	public async void Handle_UserUpdated_ReturnSuccess()
 	{
 		// Arrange
 		UserDto user = new()
@@ -154,30 +156,30 @@ public class UpdateUserCommandHandlerTests
 		Assert.True(result.IsSuccess);
 
 		_unitOfWork.Verify(
-			expression: x => x
+			x => x
 				.UserRepository
 				.FirstOrDefaultAsync(
 					u => u.Id == command.User.Id,
 					default),
-			times: Times.Once);
+			Times.Once);
 
 		_unitOfWork.Verify(
-			expression: x => x
+			x => x
 				.UserRepository
 				.AnyAsync(
 					u => u.Email == command.User.Email,
 					default),
-			times: Times.Once);
+			Times.Once);
 
 		_unitOfWork.Verify(
-			expression: x => x
+			x => x
 				.UserRepository
 				.Update(standardUser),
-			times: Times.Once);
+			Times.Once);
 
 		_unitOfWork.Verify(
-			expression: x => x
+			x => x
 				.SaveAsync(default),
-			times: Times.Once);
+			Times.Once);
 	}
 }

--- a/test/Pelican.Application.Test/Users/Commands/UpdateUser/UpdateUserCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Users/Commands/UpdateUser/UpdateUserCommandHandlerTests.cs
@@ -1,0 +1,183 @@
+using System.Linq.Expressions;
+using Moq;
+using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.Authentication;
+using Pelican.Application.Users.Commands.UpdateUser;
+using Pelican.Domain.Entities;
+using Pelican.Domain.Entities.Users;
+using Pelican.Domain.Shared;
+using Xunit;
+
+namespace Pelican.Application.Test.Users.Commands.UpdateUser;
+
+public class UpdateUserCommandHandlerTests
+{
+	private readonly Mock<IUnitOfWork> _unitOfWork = new();
+	private readonly UpdateUserCommandHandler _uut;
+
+	public UpdateUserCommandHandlerTests()
+	{
+		_uut = new(_unitOfWork.Object);
+	}
+
+	[Fact]
+	public void UpdateUserCommandHandler_UnitOfWorkNull_ThrowException()
+	{
+		// Act
+		Exception exceptionResult = Record.Exception(() =>
+			new UpdateUserCommandHandler(null!));
+
+		// Assert
+		Assert.Equal(
+			typeof(ArgumentNullException),
+			exceptionResult.GetType());
+
+		Assert.Equal(
+			"Value cannot be null. (Parameter 'unitOfWork')",
+			exceptionResult.Message);
+	}
+
+	[Fact]
+	public async void Handle_UserNotFound_ReturnFailure()
+	{
+		// Arrange
+		UserDto user = new();
+
+		UpdateUserCommand command = new(user);
+
+		_unitOfWork
+			.Setup(u => u.UserRepository.FirstOrDefaultAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync((User)null!);
+
+		// Act
+		var result = await _uut.Handle(command, default);
+
+		// Assert
+		Assert.True(result.IsFailure);
+
+		Assert.Equal(
+			new Error("User.NotFound", $"{command.User.Id} was not found"),
+			result.Error);
+
+		_unitOfWork.Verify(
+			expression: x => x
+				.UserRepository
+				.FirstOrDefaultAsync(
+					u => u.Id == command.User.Id,
+					default),
+			times: Times.Once);
+	}
+
+	[Fact]
+	public async void Handle_EmailInUse_ReturnFailure()
+	{
+		// Arrange
+		UserDto user = new()
+		{
+			Email = "email@email.com",
+		};
+
+		UpdateUserCommand command = new(user);
+
+		User standardUser = new StandardUser();
+
+		_unitOfWork
+			.Setup(u => u.UserRepository.FirstOrDefaultAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(standardUser);
+
+		_unitOfWork
+			.Setup(u => u.UserRepository.AnyAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		// Act
+		var result = await _uut.Handle(command, default);
+
+		// Assert
+		Assert.True(result.IsFailure);
+
+		Assert.Equal(
+			new Error("Email.InUse", "Email already in use"),
+			result.Error);
+
+		_unitOfWork.Verify(
+			expression: x => x
+				.UserRepository
+				.FirstOrDefaultAsync(
+					u => u.Id == command.User.Id,
+					default),
+			times: Times.Once);
+
+		_unitOfWork.Verify(
+			expression: x => x
+				.UserRepository
+				.AnyAsync(
+					u => u.Email == command.User.Email,
+					default),
+			times: Times.Once);
+	}
+
+	[Fact]
+	public async void Handle_UserUpdated_ReturnFailure()
+	{
+		// Arrange
+		UserDto user = new()
+		{
+			Email = "email@email.com",
+		};
+
+		UpdateUserCommand command = new(user);
+
+		User standardUser = new StandardUser();
+
+		_unitOfWork
+			.Setup(u => u.UserRepository.FirstOrDefaultAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(standardUser);
+
+		_unitOfWork
+			.Setup(u => u.UserRepository.AnyAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		// Act
+		var result = await _uut.Handle(command, default);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+
+		_unitOfWork.Verify(
+			expression: x => x
+				.UserRepository
+				.FirstOrDefaultAsync(
+					u => u.Id == command.User.Id,
+					default),
+			times: Times.Once);
+
+		_unitOfWork.Verify(
+			expression: x => x
+				.UserRepository
+				.AnyAsync(
+					u => u.Email == command.User.Email,
+					default),
+			times: Times.Once);
+
+		_unitOfWork.Verify(
+			expression: x => x
+				.UserRepository
+				.Update(standardUser),
+			times: Times.Once);
+
+		_unitOfWork.Verify(
+			expression: x => x
+				.SaveAsync(default),
+			times: Times.Once);
+	}
+}


### PR DESCRIPTION
Added handler to update email and name on user entity. Fails if user not found or if email is already used by another user.  