### PR TITLE
feature/PLCN-295-make-account-manager-first-and-last-name-optional

### DIFF
--- a/src/Pelican.Domain/Entities/AccountManager.cs
+++ b/src/Pelican.Domain/Entities/AccountManager.cs
@@ -4,8 +4,8 @@ using Pelican.Domain.Primitives;
 namespace Pelican.Domain.Entities;
 public class AccountManager : Entity, ITimeTracked
 {
-	private string _firstName = string.Empty;
-	private string _lastName = string.Empty;
+	private string? _firstName;
+	private string? _lastName;
 	private string _email = string.Empty;
 	private string? _phoneNumber;
 	private string? _linkedInUrl;
@@ -20,15 +20,15 @@ public class AccountManager : Entity, ITimeTracked
 
 	public long SourceUserId { get; set; }
 
-	public string FirstName
+	public string? FirstName
 	{
 		get => _firstName;
-		set => _firstName = value.CheckAndShortenExceedingString(StringLengths.Name);
+		set => _firstName = value?.CheckAndShortenExceedingString(StringLengths.Name);
 	}
-	public string LastName
+	public string? LastName
 	{
 		get => _lastName;
-		set => _lastName = value.CheckAndShortenExceedingString(StringLengths.Name);
+		set => _lastName = value?.CheckAndShortenExceedingString(StringLengths.Name);
 	}
 
 	public string Email

--- a/src/Pelican.Infrastructure.Persistence/Configurations/AccountManagerConfiguration.cs
+++ b/src/Pelican.Infrastructure.Persistence/Configurations/AccountManagerConfiguration.cs
@@ -11,12 +11,10 @@ internal class AccountManagerConfiguration : IEntityTypeConfiguration<AccountMan
 		builder.ToTable("AccountManagers");
 
 		builder.Property(p => p.FirstName)
-			.HasMaxLength(StringLengths.Name)
-			.IsRequired();
+			.HasMaxLength(StringLengths.Name);
 
 		builder.Property(p => p.LastName)
-			.HasMaxLength(StringLengths.Name)
-			.IsRequired();
+			.HasMaxLength(StringLengths.Name);
 
 		builder.Property(p => p.PictureUrl)
 			.HasMaxLength(StringLengths.Url);

--- a/src/Pelican.Infrastructure.Persistence/Migrations/20230110080644_AccountManagerNamesMadeOptional.Designer.cs
+++ b/src/Pelican.Infrastructure.Persistence/Migrations/20230110080644_AccountManagerNamesMadeOptional.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Pelican.Infrastructure.Persistence;
 
@@ -11,9 +12,10 @@ using Pelican.Infrastructure.Persistence;
 namespace Pelican.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(PelicanContext))]
-    partial class PelicanContextModelSnapshot : ModelSnapshot
+    [Migration("20230110080644_AccountManagerNamesMadeOptional")]
+    partial class AccountManagerNamesMadeOptional
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Pelican.Infrastructure.Persistence/Migrations/20230110080644_AccountManagerNamesMadeOptional.cs
+++ b/src/Pelican.Infrastructure.Persistence/Migrations/20230110080644_AccountManagerNamesMadeOptional.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Pelican.Infrastructure.Persistence.Migrations
+{
+    public partial class AccountManagerNamesMadeOptional : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "LastName",
+                table: "AccountManagers",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FirstName",
+                table: "AccountManagers",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "LastName",
+                table: "AccountManagers",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FirstName",
+                table: "AccountManagers",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+        }
+    }
+}

--- a/test/Pelican.Infrastructure.HubSpot.Test/Mapping/AccountManagers/OwnerResponseToAccountManagerTests.cs
+++ b/test/Pelican.Infrastructure.HubSpot.Test/Mapping/AccountManagers/OwnerResponseToAccountManagerTests.cs
@@ -116,7 +116,7 @@ public class OwnerResponseToAccountManagerTests
 		AccountManager result = response.ToAccountManager();
 
 		/// Assert
-		Assert.Equal(StringLengths.Name, result.FirstName.Length);
+		Assert.Equal(StringLengths.Name, result.FirstName!.Length);
 		Assert.Equal("...", result.FirstName.Substring(StringLengths.Name - 3));
 		Assert.Equal(response.Firstname.Substring(0, StringLengths.Name - 3), result.FirstName.Substring(0, StringLengths.Name - 3));
 	}
@@ -131,7 +131,7 @@ public class OwnerResponseToAccountManagerTests
 		AccountManager result = response.ToAccountManager();
 
 		/// Assert
-		Assert.Equal(StringLengths.Name, result.LastName.Length);
+		Assert.Equal(StringLengths.Name, result.LastName!.Length);
 		Assert.Equal("...", result.LastName.Substring(StringLengths.Name - 3));
 		Assert.Equal(response.Lastname.Substring(0, StringLengths.Name - 3), result.LastName.Substring(0, StringLengths.Name - 3));
 	}


### PR DESCRIPTION
AccountManager names made nullable to avoid failure as names can be null in hubspot. 