### PR TITLE
Feature/plcn 368 create update me command

### DIFF
--- a/src/Pelican.Application/Users/Commands/UpdateMe/UpdateMeCommand.cs
+++ b/src/Pelican.Application/Users/Commands/UpdateMe/UpdateMeCommand.cs
@@ -1,0 +1,6 @@
+using Pelican.Application.Abstractions.Messaging;
+using Pelican.Application.Authentication;
+
+namespace Pelican.Application.Users.Commands.UpdateMe;
+
+public record UpdateMeCommand(UserDto User) : ICommand<UserDto>;

--- a/src/Pelican.Application/Users/Commands/UpdateMe/UpdateMeCommandHandler.cs
+++ b/src/Pelican.Application/Users/Commands/UpdateMe/UpdateMeCommandHandler.cs
@@ -1,0 +1,70 @@
+using AutoMapper;
+using Pelican.Application.Abstractions.Authentication;
+using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.Abstractions.Messaging;
+using Pelican.Application.Authentication;
+using Pelican.Domain.Shared;
+
+namespace Pelican.Application.Users.Commands.UpdateMe;
+
+public class UpdateMeCommandHandler : ICommandHandler<UpdateMeCommand, UserDto>
+{
+	private readonly IUnitOfWork _unitOfWork;
+	private readonly ICurrentUserService _currentUserService;
+	private readonly IMapper _mapper;
+
+	public UpdateMeCommandHandler(
+		IUnitOfWork unitOfWork,
+		ICurrentUserService currentUserService,
+		IMapper mapper)
+	{
+		_unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+		_currentUserService = currentUserService ?? throw new ArgumentNullException(nameof(currentUserService));
+		_mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+	}
+
+	public async Task<Result<UserDto>> Handle(
+		UpdateMeCommand request,
+		CancellationToken cancellationToken)
+	{
+		var user = await _unitOfWork
+			.UserRepository
+		  	.FirstOrDefaultAsync(u => u.Id == request.User.Id, cancellationToken);
+
+		if (user is null)
+		{
+			return new Error(
+				"User.NotFound",
+				$"User with Id: {request.User.Id} was not found");
+		}
+
+		if (user.Email != _currentUserService.UserId)
+		{
+			return new Error(
+				"User.EmailNotFound",
+				$"Email: {_currentUserService.UserId} was not found on user with Id: {request.User.Id}");
+		}
+
+		if (user.Email.ToLower().Trim() != request.User.Email.ToLower().Trim()
+				&& await _unitOfWork
+					.UserRepository
+					.AnyAsync(
+						u => u.Id != user.Id
+							&& u.Email.ToLower().Trim() == request.User.Email.ToLower().Trim(),
+						cancellationToken))
+		{
+			return new Error(
+				"Email.InUse",
+				"Email already in use");
+		}
+
+		user.Name = request.User.Name.Trim();
+		user.Email = request.User.Email.ToLower().Trim();
+
+		_unitOfWork.UserRepository.Attach(user);
+
+		await _unitOfWork.SaveAsync(cancellationToken);
+
+		return _mapper.Map<UserDto>(user);
+	}
+}

--- a/src/Pelican.Application/Users/Commands/UpdateMe/UpdateMeCommandValidator.cs
+++ b/src/Pelican.Application/Users/Commands/UpdateMe/UpdateMeCommandValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using Pelican.Domain.Extensions;
+
+namespace Pelican.Application.Users.Commands.UpdateMe;
+
+public sealed class UpdateMeCommandValidator : AbstractValidator<UpdateMeCommand>
+{
+	public UpdateMeCommandValidator()
+	{
+		RuleFor(u => u.User.Id)
+			.NotEmpty();
+
+		RuleFor(u => u.User.Email)
+			.AddUserEmailValidation();
+
+		RuleFor(u => u.User.Name)
+			.AddUserNameValidation();
+
+		RuleFor(u => u.User.Role)
+			.IsInEnum();
+	}
+
+}

--- a/src/Pelican.Presentation.GraphQL/Users/UsersMutation.cs
+++ b/src/Pelican.Presentation.GraphQL/Users/UsersMutation.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Pelican.Application.Authentication;
 using Pelican.Application.Users.Commands.CreateAdmin;
 using Pelican.Application.Users.Commands.CreateStandardUser;
+using Pelican.Application.Users.Commands.UpdateMe;
 using Pelican.Application.Users.Commands.UpdatePassword;
 using Pelican.Application.Users.Commands.UpdateUser;
 
@@ -36,6 +37,14 @@ public sealed class UsersMutation
 		CancellationToken cancellationToken)
 		=> await mediator.Send(
 			new UpdateUserCommand(user),
+			cancellationToken);
+
+	public async Task<Domain.Shared.Result<UserDto>> UpdateMe(
+		UserDto user,
+		[Service] IMediator mediator,
+		CancellationToken cancellationToken)
+		=> await mediator.Send(
+			new UpdateMeCommand(user),
 			cancellationToken);
 
 	public async Task<Domain.Shared.Result<UserDto>> UpdatePassword(

--- a/test/Pelican.Application.Test/Users/Commands/UpdateMe/UpdateMeCommandHandlerTests.cs
+++ b/test/Pelican.Application.Test/Users/Commands/UpdateMe/UpdateMeCommandHandlerTests.cs
@@ -1,0 +1,334 @@
+using System.Linq.Expressions;
+using AutoMapper;
+using Moq;
+using Pelican.Application.Abstractions.Authentication;
+using Pelican.Application.Abstractions.Data.Repositories;
+using Pelican.Application.Abstractions.Messaging;
+using Pelican.Application.Authentication;
+using Pelican.Application.Users.Commands.UpdateMe;
+using Pelican.Domain.Entities;
+using Pelican.Domain.Entities.Users;
+using Pelican.Domain.Enums;
+using Pelican.Domain.Shared;
+using Xunit;
+
+namespace Pelican.Application.Test.Users.Commands.UpdateMe;
+
+public class UpdateMeCommandHandlerTest
+{
+	private readonly ICommandHandler<UpdateMeCommand, UserDto> _uut;
+	private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+	private readonly Mock<ICurrentUserService> _currentUserServiceMock = new();
+	private readonly Mock<IMapper> _mapperMock = new();
+	public UpdateMeCommandHandlerTest()
+	{
+		_uut = new UpdateMeCommandHandler(
+			_unitOfWorkMock.Object,
+			_currentUserServiceMock.Object,
+			_mapperMock.Object);
+	}
+
+	[Fact]
+	public void UpdateMeCommandHandler_UnitOfWorkNull_ThrowError()
+	{
+		// Act
+		var result = Record.Exception(() => new UpdateMeCommandHandler(
+			null!,
+			_currentUserServiceMock.Object,
+			_mapperMock.Object));
+
+		// Assert
+		Assert.IsType<ArgumentNullException>(result);
+
+		Assert.Contains(
+			"unitOfWork",
+			result.Message);
+	}
+
+	[Fact]
+	public void UpdateMeCommandHandler_CurrentUserServiceNull_ThrowError()
+	{
+		// Act
+		var result = Record.Exception(() => new UpdateMeCommandHandler(
+			_unitOfWorkMock.Object,
+			null!,
+			_mapperMock.Object));
+
+		// Assert
+		Assert.IsType<ArgumentNullException>(result);
+
+		Assert.Contains(
+			"currentUserService",
+			result.Message);
+	}
+
+	[Fact]
+	public void UpdateMeCommandHandler_MapperNull_ThrowError()
+	{
+		// Act
+		var result = Record.Exception(() => new UpdateMeCommandHandler(
+			_unitOfWorkMock.Object,
+			_currentUserServiceMock.Object,
+			null!));
+
+		// Assert
+		Assert.IsType<ArgumentNullException>(result);
+
+		Assert.Contains(
+			"mapper",
+			result.Message);
+	}
+
+	[Fact]
+	public async void Handle_UserNotFound_ReturnFailure()
+	{
+		// Arrange
+		UpdateMeCommand command = new(
+			new()
+			{
+				Id = Guid.NewGuid(),
+				Name = "newName",
+				Email = "newEmail",
+				Role = RoleEnum.Standard,
+			}
+		);
+
+		User? foundUser = null;
+
+		_unitOfWorkMock
+			.Setup(u => u.UserRepository.FirstOrDefaultAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(foundUser);
+
+		// Act
+		var result = await _uut.Handle(command, default);
+
+		// Assert
+		Assert.True(result.IsFailure);
+
+		Assert.Equal(
+			new Error(
+				"User.NotFound",
+				$"User with Id: {command.User.Id} was not found"),
+			result.Error);
+	}
+
+	[Fact]
+	public async void Handle_EmailNotFound_ReturnFailure()
+	{
+		// Arrange
+		UpdateMeCommand command = new(
+			new()
+			{
+				Id = Guid.NewGuid(),
+				Name = "newName",
+				Email = "newEmail",
+				Role = RoleEnum.Standard,
+			}
+		);
+
+		User? foundUser = new StandardUser()
+		{
+			Id = command.User.Id,
+			Name = "oldName",
+			Email = "oldEmail",
+		};
+
+		_unitOfWorkMock
+			.Setup(u => u.UserRepository.FirstOrDefaultAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(foundUser);
+
+		_currentUserServiceMock
+			.Setup(u => u.UserId)
+			.Returns("anotherEmail");
+
+		// Act
+		var result = await _uut.Handle(command, default);
+
+		// Assert
+		Assert.True(result.IsFailure);
+
+		Assert.Equal(
+			new Error(
+				"User.EmailNotFound",
+				$"Email: anotherEmail was not found on user with Id: {command.User.Id}"),
+			result.Error);
+	}
+
+	[Fact]
+	public async void Handle_EmailInUse_ReturnFailure()
+	{
+		// Arrange
+		UpdateMeCommand command = new(
+			new()
+			{
+				Id = Guid.NewGuid(),
+				Name = "newName",
+				Email = "newEmail",
+				Role = RoleEnum.Standard,
+			}
+		);
+
+		User? foundUser = new StandardUser()
+		{
+			Id = command.User.Id,
+			Name = "oldName",
+			Email = "oldEmail",
+		};
+
+		_unitOfWorkMock
+			.Setup(u => u.UserRepository.FirstOrDefaultAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(foundUser);
+
+		_currentUserServiceMock
+			.Setup(u => u.UserId)
+			.Returns("oldEmail");
+
+		_unitOfWorkMock
+			.Setup(u => u.UserRepository.AnyAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		// Act
+		var result = await _uut.Handle(command, default);
+
+		// Assert
+		Assert.True(result.IsFailure);
+
+		Assert.Equal(
+			new Error(
+				"Email.InUse",
+				"Email already in use"),
+			result.Error);
+	}
+
+	[Fact]
+	public async void Handle_NameUpdated_ReturnSuccess()
+	{
+		// Arrange
+		UpdateMeCommand command = new(
+			new()
+			{
+				Id = Guid.NewGuid(),
+				Name = "newName",
+				Email = "oldEmail",
+				Role = RoleEnum.Standard,
+			}
+		);
+
+		User? foundUser = new StandardUser()
+		{
+			Id = command.User.Id,
+			Name = "oldName",
+			Email = "oldEmail",
+		};
+
+		UserDto returnUserDto = command.User;
+
+		_unitOfWorkMock
+			.Setup(u => u.UserRepository.FirstOrDefaultAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(foundUser);
+
+		_currentUserServiceMock
+			.Setup(u => u.UserId)
+			.Returns("oldEmail");
+
+		_unitOfWorkMock
+			.Setup(u => u.UserRepository.AnyAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		_mapperMock
+			.Setup(u => u.Map<UserDto>(It.IsAny<User>()))
+			.Returns(returnUserDto);
+
+		// Act
+		var result = await _uut.Handle(command, default);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+
+		Assert.Equal(
+			returnUserDto,
+			result.Value);
+
+		_unitOfWorkMock.Verify(
+			u => u.UserRepository.Attach(foundUser),
+			Times.Once);
+
+		_unitOfWorkMock.Verify(
+			u => u.SaveAsync(default),
+			Times.Once);
+	}
+
+	[Fact]
+	public async void Handle_NameAndEmailUpdated_ReturnSuccess()
+	{
+		// Arrange
+		UpdateMeCommand command = new(
+			new()
+			{
+				Id = Guid.NewGuid(),
+				Name = "newName",
+				Email = "newEmail",
+				Role = RoleEnum.Standard,
+			}
+		);
+
+		User? foundUser = new StandardUser()
+		{
+			Id = command.User.Id,
+			Name = "oldName",
+			Email = "oldEmail",
+		};
+
+		UserDto returnUserDto = command.User;
+
+		_unitOfWorkMock
+			.Setup(u => u.UserRepository.FirstOrDefaultAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(foundUser);
+
+		_currentUserServiceMock
+			.Setup(u => u.UserId)
+			.Returns("oldEmail");
+
+		_unitOfWorkMock
+			.Setup(u => u.UserRepository.AnyAsync(
+				It.IsAny<Expression<Func<User, bool>>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		_mapperMock
+			.Setup(u => u.Map<UserDto>(It.IsAny<User>()))
+			.Returns(returnUserDto);
+
+		// Act
+		var result = await _uut.Handle(command, default);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+
+		Assert.Equal(
+			returnUserDto,
+			result.Value);
+
+		_unitOfWorkMock.Verify(
+			u => u.UserRepository.Attach(foundUser),
+			Times.Once);
+
+		_unitOfWorkMock.Verify(
+			u => u.SaveAsync(default),
+			Times.Once);
+	}
+}

--- a/test/Pelican.Application.Test/Users/Commands/UpdateMe/UpdateMeCommandValidatorTests.cs
+++ b/test/Pelican.Application.Test/Users/Commands/UpdateMe/UpdateMeCommandValidatorTests.cs
@@ -1,0 +1,123 @@
+using FluentValidation.TestHelper;
+using Pelican.Application.Users.Commands.UpdateMe;
+using Pelican.Domain;
+using Pelican.Domain.Enums;
+using Xunit;
+
+namespace Pelican.Application.Test.Users.Commands.UpdateMe;
+
+public class UpdateMeCommandValidatorTests
+{
+	private readonly UpdateMeCommandValidator _uut;
+
+	public UpdateMeCommandValidatorTests()
+	{
+		_uut = new UpdateMeCommandValidator();
+	}
+
+	[Fact]
+	public void UpdateMeCommandValidator_EmptyStringOrDefaultValue_ReturnsError()
+	{
+		// Arrange
+		UpdateMeCommand command = new(new()
+		{
+			Id = Guid.Empty,
+			Email = string.Empty,
+			Name = string.Empty,
+		});
+
+		// Act
+		var result = _uut.TestValidate(command);
+
+		// Assert
+		result
+			.ShouldHaveValidationErrorFor(command => command.User.Id);
+		result
+			.ShouldHaveValidationErrorFor(command => command.User.Email);
+		result
+			.ShouldHaveValidationErrorFor(command => command.User.Name);
+		result
+			.ShouldHaveValidationErrorFor(command => command.User.Role);
+	}
+
+	[Fact]
+	public void UpdateMeCommandValidator_TooLongStringOrDefaultValue_ReturnsError()
+	{
+		// Arrange
+		UpdateMeCommand command = new(new()
+		{
+			Id = Guid.Empty,
+			Email = new string('x', StringLengths.Email * 2),
+			Name = new string('x', StringLengths.Name * 2),
+		});
+
+		// Act
+		var result = _uut.TestValidate(command);
+
+		// Assert
+		result
+			.ShouldHaveValidationErrorFor(command => command.User.Id);
+		result
+			.ShouldHaveValidationErrorFor(command => command.User.Email)
+			.WithErrorMessage("User Email cannot be longer than " + $"{StringLengths.Email}.");
+		result
+			.ShouldHaveValidationErrorFor(command => command.User.Name)
+			.WithErrorMessage("User Name cannot be longer than " + $"{StringLengths.Name}.");
+		result
+			.ShouldHaveValidationErrorFor(command => command.User.Role);
+	}
+
+	[Fact]
+	public void UpdateMeCommandValidator_EmailWrongFormat_ReturnsError()
+	{
+		// Arrange
+		UpdateMeCommand command = new(new()
+		{
+			Id = Guid.NewGuid(),
+			Email = "testWronglyFormattedEmail",
+			Name = "testName",
+			Role = RoleEnum.Admin,
+		});
+
+		// Act
+		var result = _uut.TestValidate(command);
+
+		// Assert
+		result
+			.ShouldNotHaveValidationErrorFor(command => command.User.Id);
+		result
+			.ShouldHaveValidationErrorFor(command => command.User.Email)
+			.WithErrorMessage("User Email is not a valid email.");
+		result
+			.ShouldNotHaveValidationErrorFor(command => command.User.Name);
+		result
+			.ShouldNotHaveValidationErrorFor(command => command.User.Role);
+	}
+
+	[Fact]
+	public void UpdateMeCommandValidator_NoEmptyStringsOrDefaultValues_ReturnsNoError()
+	{
+		// Arrange
+		UpdateMeCommand command = new(new()
+		{
+			Id = Guid.NewGuid(),
+			Email = "email@email.com",
+			Name = "Nem Name",
+			Role = RoleEnum.Standard,
+		});
+
+		// Act
+		TestValidationResult<UpdateMeCommand> result = _uut.TestValidate(command);
+
+		// Assert
+		result
+			.ShouldNotHaveValidationErrorFor(command => command.User.Id);
+		result
+			.ShouldNotHaveValidationErrorFor(command => command.User.Email);
+		result
+			.ShouldNotHaveValidationErrorFor(command => command.User.Name);
+		result
+			.ShouldNotHaveValidationErrorFor(command => command.User.Role);
+	}
+
+}

--- a/test/Pelican.Presentation.GraphQL.Test/UsersMutationTests.cs
+++ b/test/Pelican.Presentation.GraphQL.Test/UsersMutationTests.cs
@@ -7,6 +7,7 @@ using Pelican.Application.Users.Commands.UpdateUser;
 using Pelican.Application.Users.Commands.UpdatePassword;
 using Pelican.Application.Users.Commands.CreateStandardUser;
 using Pelican.Application.Authentication;
+using Pelican.Application.Users.Commands.UpdateMe;
 
 namespace Pelican.Presentation.GraphQL.Test;
 
@@ -15,7 +16,7 @@ public class UsersMutationTests
 	private readonly UsersMutation _uut = new();
 
 	[Fact]
-	public async Task CreateStandardUser()
+	public async Task CreateStandardUser_VerifyCommandSend()
 	{
 		// Arrange
 		const string NAME = "name";
@@ -41,7 +42,7 @@ public class UsersMutationTests
 	}
 
 	[Fact]
-	public async Task CreateAdmin()
+	public async Task CreateAdmin_VerifyCommandSend()
 	{
 		// Arrange
 		const string NAME = "name";
@@ -67,7 +68,7 @@ public class UsersMutationTests
 	}
 
 	[Fact]
-	public async Task UpdateUser()
+	public async Task UpdateUser_VerifyCommandSend()
 	{
 		// Arrange
 		UserDto user = new();
@@ -89,7 +90,29 @@ public class UsersMutationTests
 	}
 
 	[Fact]
-	public async Task UpdatePassword()
+	public async Task UpdateMe_VerifyCommandSend()
+	{
+		// Arrange
+		UserDto user = new();
+
+		Mock<IMediator> mediatorMock = new();
+
+		// Act
+		var result = await _uut.UpdateMe(
+			user,
+			mediatorMock.Object,
+			default);
+
+		// Assert
+		mediatorMock.Verify(
+			m => m.Send(It.Is<UpdateMeCommand>(
+				x => x.User == user),
+				default),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task UpdatePassword_VerifyCommandSend()
 	{
 		// Arrange
 		const string PASSWORD = "password";


### PR DESCRIPTION
Added command to update your own userprofile (only email and name) without having admin role. 
Implemented validation and handler. 
Handler fails if user does not exists, if logged in user is not the same as the user being modified or the new email is already in use by another user. 

Added GraphQL mutation endpoint to call the command. 